### PR TITLE
improve e2e testing code

### DIFF
--- a/proxy/src/test/e2e/client.rs
+++ b/proxy/src/test/e2e/client.rs
@@ -25,7 +25,7 @@ pub async fn new_web_client(
     }
 
     let resp = default_client
-        .get(format!("http://{}/ca", runtime.meta_addr()))
+        .get(format!("http://{}/ca", runtime.meta_socket_addr()))
         .send()
         .await
         .unwrap();

--- a/proxy/src/test/e2e/har.rs
+++ b/proxy/src/test/e2e/har.rs
@@ -1,24 +1,6 @@
-use rama::{
-    extensions::ExtensionsMut as _,
-    http::{Request, layer::har::spec::Request as HarRequest},
-    net::{Protocol, address::ProxyAddress},
-};
-
-use crate::test::e2e::runtime::Runtime;
+use rama::http::{Request, layer::har::spec::Request as HarRequest};
 
 pub fn parse_har_request(data: &str) -> Request {
     let har_req: HarRequest = serde_json::from_str(data).unwrap();
     har_req.try_into().unwrap()
-}
-
-pub fn parse_har_request_as_proxy_req(runtime: &Runtime, data: &str) -> Request {
-    let mut req = parse_har_request(data);
-
-    req.extensions_mut().insert(ProxyAddress {
-        protocol: Some(Protocol::HTTP),
-        address: runtime.proxy_addr().into(),
-        credential: None,
-    });
-
-    req
 }

--- a/proxy/src/test/e2e/runtime.rs
+++ b/proxy/src/test/e2e/runtime.rs
@@ -1,7 +1,14 @@
 use std::{io::ErrorKind, path::PathBuf, sync::LazyLock, time::Duration};
 
 use clap::Parser;
-use rama::net::address::{DomainAddress, SocketAddress};
+use rama::{
+    net::{
+        Protocol,
+        address::{DomainAddress, ProxyAddress, SocketAddress},
+        user::{Basic, ProxyCredential},
+    },
+    utils::str::NonEmptyStr,
+};
 
 use crate::Args;
 
@@ -15,7 +22,7 @@ pub(super) struct Runtime {
 
 impl Runtime {
     #[inline(always)]
-    pub fn meta_addr(&self) -> SocketAddress {
+    pub fn meta_socket_addr(&self) -> SocketAddress {
         self.meta_addr
     }
 
@@ -25,8 +32,38 @@ impl Runtime {
     }
 
     #[inline(always)]
-    pub fn proxy_addr(&self) -> SocketAddress {
+    pub fn proxy_socket_addr(&self) -> SocketAddress {
         self.proxy_addr
+    }
+
+    #[inline(always)]
+    pub fn http_proxy_addr(&self) -> ProxyAddress {
+        ProxyAddress {
+            protocol: Some(Protocol::HTTP),
+            address: self.proxy_socket_addr().into(),
+            credential: None,
+        }
+    }
+
+    #[inline(always)]
+    #[expect(unused)] // NOTE: remove the unused exception first time you need it
+    pub fn http_proxy_addr_with_username(&self, username: &'static str) -> ProxyAddress {
+        ProxyAddress {
+            protocol: Some(Protocol::HTTP),
+            address: self.proxy_socket_addr().into(),
+            credential: Some(ProxyCredential::Basic(Basic::new_insecure(
+                NonEmptyStr::try_from(username).unwrap(),
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    pub fn socks5_proxy_addr(&self) -> ProxyAddress {
+        ProxyAddress {
+            protocol: Some(Protocol::SOCKS5),
+            address: self.proxy_socket_addr().into(),
+            credential: None,
+        }
     }
 }
 

--- a/proxy/src/test/e2e/test_connectivity.rs
+++ b/proxy/src/test/e2e/test_connectivity.rs
@@ -45,7 +45,7 @@ async fn test_connectivity_https_failure_no_trust(
             .get(format!("https://{CONNECTIVITY_DOMAIN}"))
             .extension(ProxyAddress {
                 protocol: Some(Protocol::HTTP),
-                address: runtime.proxy_addr().into(),
+                address: runtime.proxy_socket_addr().into(),
                 credential: None,
             })
             .send()
@@ -74,7 +74,7 @@ async fn test_connectivity_http(
         .get(format!("http://{CONNECTIVITY_DOMAIN}"))
         .extension(ProxyAddress {
             protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
+            address: runtime.proxy_socket_addr().into(),
             credential: None,
         })
         .send()
@@ -97,7 +97,7 @@ async fn test_connectivity_http_over_sock5(
         .get(format!("http://{CONNECTIVITY_DOMAIN}"))
         .extension(ProxyAddress {
             protocol: Some(Protocol::SOCKS5),
-            address: runtime.proxy_addr().into(),
+            address: runtime.proxy_socket_addr().into(),
             credential: None,
         })
         .send()
@@ -120,7 +120,7 @@ async fn test_connectivity_http_with_username_labels(
         .get(format!("http://{CONNECTIVITY_DOMAIN}"))
         .extension(ProxyAddress {
             protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
+            address: runtime.proxy_socket_addr().into(),
             credential: Some(ProxyCredential::Basic(basic!(
                 "test-foo-min_pkg_age-1h_30m"
             ))),
@@ -145,7 +145,7 @@ async fn test_connectivity_https(
         .get(format!("https://{CONNECTIVITY_DOMAIN}"))
         .extension(ProxyAddress {
             protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
+            address: runtime.proxy_socket_addr().into(),
             credential: None,
         })
         .send()
@@ -168,7 +168,7 @@ async fn test_connectivity_https_over_socks5(
         .get(format!("https://{CONNECTIVITY_DOMAIN}"))
         .extension(ProxyAddress {
             protocol: Some(Protocol::SOCKS5),
-            address: runtime.proxy_addr().into(),
+            address: runtime.proxy_socket_addr().into(),
             credential: None,
         })
         .send()

--- a/proxy/src/test/e2e/test_meta.rs
+++ b/proxy/src/test/e2e/test_meta.rs
@@ -34,7 +34,7 @@ mod http {
         client: &impl Service<Request, Output = Response, Error = OpaqueError>,
     ) {
         let payload = client
-            .get(format!("http://{}", runtime.meta_addr()))
+            .get(format!("http://{}", runtime.meta_socket_addr()))
             .send()
             .await
             .unwrap()
@@ -50,7 +50,7 @@ mod http {
         client: &impl Service<Request, Output = Response, Error = OpaqueError>,
     ) {
         let resp = client
-            .get(format!("http://{}/ping", runtime.meta_addr()))
+            .get(format!("http://{}/ping", runtime.meta_socket_addr()))
             .send()
             .await
             .unwrap();
@@ -67,7 +67,7 @@ mod http {
         client: &impl Service<Request, Output = Response, Error = OpaqueError>,
     ) {
         let resp = client
-            .get(format!("http://{}/ca", runtime.meta_addr()))
+            .get(format!("http://{}/ca", runtime.meta_socket_addr()))
             .send()
             .await
             .unwrap();
@@ -85,7 +85,7 @@ mod http {
         client: &impl Service<Request, Output = Response, Error = OpaqueError>,
     ) {
         let resp = client
-            .get(format!("http://{}/pac", runtime.meta_addr()))
+            .get(format!("http://{}/pac", runtime.meta_socket_addr()))
             .send()
             .await
             .unwrap();

--- a/proxy/src/test/e2e/test_proxy/firewall_chrome.rs
+++ b/proxy/src/test/e2e/test_proxy/firewall_chrome.rs
@@ -7,11 +7,9 @@ use rama::{
 use crate::test::e2e;
 
 pub(super) async fn test_google_har_replay_blocked_plugin(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
-    let req = e2e::har::parse_har_request_as_proxy_req(
-        runtime,
+    let req = e2e::har::parse_har_request(
         r##"{
     "method": "GET",
     "url": "https://clients2.google.com/service/update2/crx?response=redirect&os=mac&arch=arm64&os_arch=arm64&prod=chromecrx&prodchannel=&prodversion=143.0.7499.111&lang=en-US&acceptformat=crx3,puff&x=id%3Dlajondecmobodlejlcjllhojikagldgd%26installsource%3Dondemand%26uc&authuser=0",

--- a/proxy/src/test/e2e/test_proxy/firewall_vscode.rs
+++ b/proxy/src/test/e2e/test_proxy/firewall_vscode.rs
@@ -2,22 +2,13 @@ use rama::{
     Service,
     error::OpaqueError,
     http::{Request, Response, StatusCode, service::client::HttpClientExt as _},
-    net::{Protocol, address::ProxyAddress},
 };
 
-use crate::test::e2e;
-
 pub(super) async fn test_vscode_http_plugin_malware_blocked(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
     let resp = client
         .get("http://gallery.vsassets.io/extensions/pythoner/pythontheme/whatever?a=b")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
         .send()
         .await
         .unwrap();
@@ -26,16 +17,10 @@ pub(super) async fn test_vscode_http_plugin_malware_blocked(
 }
 
 pub(super) async fn test_vscode_http_plugin_ok(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
     let resp = client
         .get("http://gallery.vsassets.io/extensions/python/python/whatever?a=b")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
         .send()
         .await
         .unwrap();
@@ -44,16 +29,10 @@ pub(super) async fn test_vscode_http_plugin_ok(
 }
 
 pub(super) async fn test_vscode_https_plugin_malware_blocked(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
     let resp = client
         .get("https://gallery.vsassets.io/extensions/pythoner/pythontheme/whatever?a=b")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
         .send()
         .await
         .unwrap();
@@ -62,16 +41,10 @@ pub(super) async fn test_vscode_https_plugin_malware_blocked(
 }
 
 pub(super) async fn test_vscode_https_plugin_ok(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
     let resp = client
         .get("https://gallery.vsassets.io/extensions/python/python/whatever?a=b")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
         .send()
         .await
         .unwrap();

--- a/proxy/src/test/e2e/test_proxy/mod.rs
+++ b/proxy/src/test/e2e/test_proxy/mod.rs
@@ -3,24 +3,27 @@ mod no_firewall;
 mod firewall_chrome;
 mod firewall_vscode;
 
+use rama::{Layer as _, layer::AddInputExtensionLayer};
+
 use crate::test::e2e;
 
 pub(super) async fn test_proxy(runtime: &e2e::runtime::Runtime) {
-    let client = e2e::client::new_web_client(runtime, true).await;
+    let client = AddInputExtensionLayer::new(runtime.http_proxy_addr())
+        .into_layer(e2e::client::new_web_client(runtime, true).await);
 
     tokio::join!(
-        self::no_firewall::test_http_example_com_proxy_http(runtime, &client),
+        self::no_firewall::test_http_example_com_proxy_http(&client),
         self::no_firewall::test_http_example_com_proxy_socks5(runtime, &client),
-        self::no_firewall::test_https_example_com_proxy_http(runtime, &client),
+        self::no_firewall::test_https_example_com_proxy_http(&client),
         self::no_firewall::test_https_example_com_proxy_socks5(runtime, &client),
     );
 
-    self::firewall_chrome::test_google_har_replay_blocked_plugin(runtime, &client).await;
+    self::firewall_chrome::test_google_har_replay_blocked_plugin(&client).await;
 
     tokio::join!(
-        self::firewall_vscode::test_vscode_http_plugin_malware_blocked(runtime, &client),
-        self::firewall_vscode::test_vscode_http_plugin_ok(runtime, &client),
-        self::firewall_vscode::test_vscode_https_plugin_malware_blocked(runtime, &client),
-        self::firewall_vscode::test_vscode_https_plugin_ok(runtime, &client),
+        self::firewall_vscode::test_vscode_http_plugin_malware_blocked(&client),
+        self::firewall_vscode::test_vscode_http_plugin_ok(&client),
+        self::firewall_vscode::test_vscode_https_plugin_malware_blocked(&client),
+        self::firewall_vscode::test_vscode_https_plugin_ok(&client),
     );
 }

--- a/proxy/src/test/e2e/test_proxy/no_firewall.rs
+++ b/proxy/src/test/e2e/test_proxy/no_firewall.rs
@@ -2,25 +2,14 @@ use rama::{
     Service,
     error::OpaqueError,
     http::{BodyExtractExt, Request, Response, StatusCode, service::client::HttpClientExt as _},
-    net::{Protocol, address::ProxyAddress},
 };
 
 use crate::test::e2e;
 
 pub(super) async fn test_http_example_com_proxy_http(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
-    let resp = client
-        .get("http://example.com")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
-        .send()
-        .await
-        .unwrap();
+    let resp = client.get("http://example.com").send().await.unwrap();
 
     assert_eq!(StatusCode::OK, resp.status());
 
@@ -35,11 +24,7 @@ pub(super) async fn test_http_example_com_proxy_socks5(
 ) {
     let resp = client
         .get("http://example.com")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::SOCKS5),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
+        .extension(runtime.socks5_proxy_addr())
         .send()
         .await
         .unwrap();
@@ -52,19 +37,9 @@ pub(super) async fn test_http_example_com_proxy_socks5(
 }
 
 pub(super) async fn test_https_example_com_proxy_http(
-    runtime: &e2e::runtime::Runtime,
     client: &impl Service<Request, Output = Response, Error = OpaqueError>,
 ) {
-    let resp = client
-        .get("https://example.com")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::HTTP),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
-        .send()
-        .await
-        .unwrap();
+    let resp = client.get("https://example.com").send().await.unwrap();
 
     assert_eq!(StatusCode::OK, resp.status());
 
@@ -79,11 +54,7 @@ pub(super) async fn test_https_example_com_proxy_socks5(
 ) {
     let resp = client
         .get("https://example.com")
-        .extension(ProxyAddress {
-            protocol: Some(Protocol::SOCKS5),
-            address: runtime.proxy_addr().into(),
-            credential: None,
-        })
+        .extension(runtime.socks5_proxy_addr())
         .send()
         .await
         .unwrap();


### PR DESCRIPTION
- ensure test_all (e2e app) is multithreaded (for multi-threaded systems)
- optimise concurrent paths to wall off what is too big
- make proxy tests easier to write and harder to make mistakes:
  - no proxy test should ever _not_ go via the proxy, so by default the client will now already have the http proxy addr inserted
  - only in case we want to test a proxy (conn) with (http) username labels or want to test the socks5 proxy would we actually need to insert it explicitly
  - even when we need to have a different proxy addr, make it easier to create it by providing utility methods for these

Especially the error-prone part of the e2e proxy tests before, was a potential footgun. Because if someone ever forgot to add one of the possible proxy addresses, you would make an actual remote request, whoops. Now this is no longer the case.