### PR TITLE
remove symbolic link for proxy/README.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ gofmt -w .
 The proxy is written in Rust.
 
 Learn more about the Proxy, what it is and how to use it,
-in the Proxy README: [../proxy/README.md](../proxy/README.md).
+in the Proxy README: [../docs/proxy.md](../docs/proxy.md).
 
 Using `just` you can using a single command: format code,
 sort `Cargo.toml` dependencies, lint (`clippy`), check code can compile

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A security-focused SOCKS5/HTTP(S) system proxy
 built with <https://ramaproxy.org/>.
 
 Read more in the proxy readme:
-[./proxy/README.md](./proxy/README.md).
+[./docs/proxy.md](./docs/proxy.md).
 
 ## Contributing
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 rust-version = "1.91"
+readme = "../docs/proxy.md"
 resolver = "3"
 
 [features]

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,1 +1,0 @@
-../docs/proxy.md


### PR DESCRIPTION
The experience of the links isn't very nice,
when used from within the GitHub web view it seems.

So better we just drop it all together.