### PR TITLE
Avoid warning logs when cache is not present

### DIFF
--- a/proxy/src/firewall/malware_list.rs
+++ b/proxy/src/firewall/malware_list.rs
@@ -51,16 +51,28 @@ impl RemoteMalwareList {
         };
 
         let (malware_trie, e_tag) = match client.load_cached_malware_trie().await {
-            Ok(cached_info) => {
+            Ok(Some(cached_info)) => {
                 tracing::debug!(
                     "create new remote malware list (uri: {}) with cached trie",
                     client.uri
                 );
                 cached_info
             }
+            Ok(None) => {
+                tracing::debug!(
+                    "no cached malware list found for remote endpoint (uri: {}); download fresh list",
+                    client.uri
+                );
+
+                client
+                    .download_malware_trie(None)
+                    .await
+                    .context("download new malware list")?
+                    .context("new malware list not available")?
+            }
             Err(err) => {
                 tracing::warn!(
-                    "failed to create new remote malware list (uri: {}) with cached trie; try to fetch new trie; err = {err}",
+                    "failed to load cached malware list for remote endpoint (uri: {}); download fresh list; err = {err}",
                     client.uri
                 );
 
@@ -202,7 +214,9 @@ where
         });
     }
 
-    async fn load_cached_malware_trie(&self) -> Result<(MalwareTrie, Option<ArcStr>), OpaqueError> {
+    async fn load_cached_malware_trie(
+        &self,
+    ) -> Result<Option<(MalwareTrie, Option<ArcStr>)>, OpaqueError> {
         tokio::task::spawn_blocking({
             let storage = self.sync_storage.clone();
             let filename = self.filename.clone();
@@ -227,15 +241,17 @@ where
 fn load_cached_malware_trie_sync_inner(
     storage: SyncCompactDataStorage,
     filename: ArcStr,
-) -> Result<(MalwareTrie, Option<ArcStr>), OpaqueError> {
-    let cached_malware_trie: CachedMalwareTrie = storage
-        .load(&filename)
-        .context("storage failure")?
-        .context("cached malware list not found")?;
+) -> Result<Option<(MalwareTrie, Option<ArcStr>)>, OpaqueError> {
+    let cached_malware_trie: Option<CachedMalwareTrie> =
+        storage.load(&filename).context("storage failure")?;
+
+    let Some(cached_malware_trie) = cached_malware_trie else {
+        return Ok(None);
+    };
 
     let trie = trie_from_malware_list(cached_malware_trie.list);
 
-    Ok((trie, cached_malware_trie.e_tag))
+    Ok(Some((trie, cached_malware_trie.e_tag)))
 }
 
 async fn remote_list_update_loop<C>(


### PR DESCRIPTION
Reduce logging noise as seen during testing

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Handled missing cache by downloading fresh list and reduced logs

**🔧 Refactors**
* Changed cached-trie loader to return Option instead of error


<sup>[More info](https://app.aikido.dev/featurebranch/scan/74730013?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->