### PR TITLE
Add signing step for Windows binaries in CI workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -141,6 +141,13 @@ jobs:
           mv bin/SafeChainProxy.${{ matrix.arch }}.exe bin/SafeChainProxy.exe
         shell: bash
 
+      - name: Sign binaries
+        run: |
+          dotnet tool install --global AzureSignTool --version 6.0.1
+          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.globalsign.com/tsa/advanced -v "bin/SafeChainAgent.exe"
+          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.globalsign.com/tsa/advanced -v "bin/SafeChainProxy.exe"
+        shell: bash
+
       - name: Install WiX Toolset
         run: dotnet tool install -g wix
 
@@ -150,6 +157,7 @@ jobs:
       - name: Build MSI installer
         run: |
           .\packaging\windows\build-msi.ps1 -Version "${{ inputs.version || 'dev' }}" -Arch "${{ matrix.arch }}" -BinDir ".\bin" -OutputDir "."
+          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.globalsign.com/tsa/advanced -v "SafeChainAgent.${{ matrix.arch }}.msi"
         shell: pwsh
 
       - name: Upload MSI artifact


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added CI code-signing for Windows binaries and MSI using AzureSignTool


<sup>[More info](https://app.aikido.dev/featurebranch/scan/75225197?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->