### PR TITLE
Add endpoint to expose blocked event data

### DIFF
--- a/proxy/src/firewall/events.rs
+++ b/proxy/src/firewall/events.rs
@@ -1,0 +1,139 @@
+use std::{
+    collections::VecDeque,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BlockedArtifact {
+    Npm { name: String, version: String },
+    Pypi { name: String, version: String },
+    VscodeExtension { id: String },
+    ChromeExtension { id: String },
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockedEventInfo {
+    pub product: String,
+    pub artifact: BlockedArtifact,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedEvent {
+    #[serde(rename = "ts_ms", alias = "unix_ts_ms")]
+    pub unix_ts_ms: u64,
+    pub product: String,
+    pub artifact: BlockedArtifact,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedEventsResponse {
+    #[serde(rename = "now_ms", alias = "now_unix_ms")]
+    pub now_unix_ms: u64,
+    pub retention_ms: u64,
+    pub total_retained: usize,
+    pub events: Vec<BlockedEvent>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct EventsQuery {
+    #[serde(alias = "since_ms")]
+    pub since_unix_ms: Option<u64>,
+    #[serde(alias = "until_ms")]
+    pub until_unix_ms: Option<u64>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct BlockedEventsStore {
+    state: Mutex<StoreState>,
+    retention: Duration,
+    max_events: usize,
+}
+
+#[derive(Debug, Default)]
+struct StoreState {
+    events: VecDeque<BlockedEvent>,
+}
+
+impl BlockedEventsStore {
+    pub fn new(retention: Duration, max_events: usize) -> Self {
+        Self {
+            state: Mutex::new(StoreState::default()),
+            retention,
+            max_events: max_events.max(1),
+        }
+    }
+
+    pub fn record(&self, info: BlockedEventInfo) {
+        let now_unix_ms = now_unix_ms();
+
+        let mut state = self.state.lock();
+        prune_locked(&mut state, now_unix_ms, self.retention);
+
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: now_unix_ms,
+            product: info.product,
+            artifact: info.artifact,
+        });
+
+        while state.events.len() > self.max_events {
+            state.events.pop_front();
+        }
+    }
+
+    pub fn query(&self, query: EventsQuery) -> BlockedEventsResponse {
+        let now_unix_ms = now_unix_ms();
+
+        let mut state = self.state.lock();
+        prune_locked(&mut state, now_unix_ms, self.retention);
+
+        let since_ms = query.since_unix_ms.unwrap_or(0);
+        let until_ms = query.until_unix_ms.unwrap_or(u64::MAX);
+
+        let mut events: Vec<BlockedEvent> = state
+            .events
+            .iter()
+            .filter(|e| e.unix_ts_ms >= since_ms && e.unix_ts_ms <= until_ms)
+            .cloned()
+            .collect();
+
+        if let Some(limit) = query.limit
+            && events.len() > limit
+        {
+            // Prefer the most recent events.
+            events.drain(0..(events.len() - limit));
+        }
+
+        BlockedEventsResponse {
+            now_unix_ms,
+            retention_ms: self.retention.as_millis() as u64,
+            total_retained: state.events.len(),
+            events,
+        }
+    }
+}
+
+fn prune_locked(state: &mut StoreState, now_ms: u64, retention: Duration) {
+    let retention_ms = retention.as_millis() as u64;
+    let min_ts = now_ms.saturating_sub(retention_ms);
+
+    while state.events.front().is_some_and(|e| e.unix_ts_ms < min_ts) {
+        state.events.pop_front();
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+#[path = "events_tests.rs"]
+mod tests;

--- a/proxy/src/firewall/events_tests.rs
+++ b/proxy/src/firewall/events_tests.rs
@@ -1,0 +1,175 @@
+use super::*;
+
+#[test]
+fn blocked_artifact_serializes_with_kind_tag() {
+    let artifact = BlockedArtifact::Npm {
+        name: "foo".to_string(),
+        version: "1.3.0".to_string(),
+    };
+
+    let json = serde_json::to_value(&artifact).unwrap();
+
+    assert_eq!(json["kind"], "npm");
+    assert_eq!(json["name"], "foo");
+    assert_eq!(json["version"], "1.3.0");
+}
+
+#[test]
+fn events_query_deserializes_with_defaults() {
+    let query: EventsQuery = serde_json::from_str("{}").unwrap();
+
+    assert_eq!(query.since_unix_ms, None);
+    assert_eq!(query.until_unix_ms, None);
+    assert_eq!(query.limit, None);
+}
+
+#[test]
+fn store_enforces_max_events_min_1() {
+    let store = BlockedEventsStore::new(Duration::from_secs(3600), 0);
+
+    store.record(BlockedEventInfo {
+        product: "pypi".to_string(),
+        artifact: BlockedArtifact::Pypi {
+            name: "foo".to_string(),
+            version: "1.0.0".to_string(),
+        },
+    });
+
+    store.record(BlockedEventInfo {
+        product: "pypi".to_string(),
+        artifact: BlockedArtifact::Pypi {
+            name: "bar".to_string(),
+            version: "2.0.0".to_string(),
+        },
+    });
+
+    let resp = store.query(EventsQuery::default());
+    assert_eq!(resp.total_retained, 1);
+    assert_eq!(resp.events.len(), 1);
+}
+
+#[test]
+fn store_prunes_by_max_events_keeps_most_recent() {
+    let store = BlockedEventsStore::new(Duration::from_secs(3600), 2);
+
+    store.record(BlockedEventInfo {
+        product: "npm".to_string(),
+        artifact: BlockedArtifact::Npm {
+            name: "a".to_string(),
+            version: "1".to_string(),
+        },
+    });
+
+    store.record(BlockedEventInfo {
+        product: "npm".to_string(),
+        artifact: BlockedArtifact::Npm {
+            name: "b".to_string(),
+            version: "1".to_string(),
+        },
+    });
+
+    store.record(BlockedEventInfo {
+        product: "npm".to_string(),
+        artifact: BlockedArtifact::Npm {
+            name: "c".to_string(),
+            version: "1".to_string(),
+        },
+    });
+
+    let resp = store.query(EventsQuery::default());
+    assert_eq!(resp.total_retained, 2);
+    assert_eq!(resp.events.len(), 2);
+}
+
+#[test]
+fn store_prunes_by_retention() {
+    let store = BlockedEventsStore::new(Duration::from_secs(1), 100);
+
+    let base_ms = now_unix_ms();
+    let old_ms = base_ms.saturating_sub(10_000);
+    let recent_ms = base_ms.saturating_sub(10);
+    {
+        let mut state = store.state.lock();
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: old_ms,
+            product: "pypi".to_string(),
+            artifact: BlockedArtifact::Unknown,
+        });
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: recent_ms,
+            product: "pypi".to_string(),
+            artifact: BlockedArtifact::Unknown,
+        });
+    }
+
+    let resp = store.query(EventsQuery::default());
+    assert_eq!(resp.total_retained, 1);
+    assert_eq!(resp.events.len(), 1);
+    assert_eq!(resp.events[0].unix_ts_ms, recent_ms);
+}
+
+#[test]
+fn query_filters_by_time_window() {
+    let store = BlockedEventsStore::new(Duration::from_secs(3600), 100);
+
+    let base_ms = now_unix_ms();
+    let t1 = base_ms.saturating_sub(3000);
+    let t2 = base_ms.saturating_sub(2000);
+    let t3 = base_ms.saturating_sub(1000);
+
+    {
+        let mut state = store.state.lock();
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: t1,
+            product: "npm".to_string(),
+            artifact: BlockedArtifact::Unknown,
+        });
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: t2,
+            product: "npm".to_string(),
+            artifact: BlockedArtifact::Unknown,
+        });
+        state.events.push_back(BlockedEvent {
+            unix_ts_ms: t3,
+            product: "npm".to_string(),
+            artifact: BlockedArtifact::Unknown,
+        });
+    }
+
+    let resp = store.query(EventsQuery {
+        since_unix_ms: Some(base_ms.saturating_sub(2500)),
+        until_unix_ms: Some(base_ms.saturating_sub(1500)),
+        limit: None,
+    });
+
+    assert_eq!(resp.events.len(), 1);
+    assert_eq!(resp.events[0].unix_ts_ms, t2);
+}
+
+#[test]
+fn query_limit_prefers_most_recent() {
+    let store = BlockedEventsStore::new(Duration::from_secs(3600), 100);
+
+    let base_ms = now_unix_ms();
+
+    {
+        let mut state = store.state.lock();
+        for offset in (1..=5).rev() {
+            state.events.push_back(BlockedEvent {
+                unix_ts_ms: base_ms.saturating_sub(offset),
+                product: "npm".to_string(),
+                artifact: BlockedArtifact::Unknown,
+            });
+        }
+    }
+
+    let resp = store.query(EventsQuery {
+        since_unix_ms: None,
+        until_unix_ms: None,
+        limit: Some(2),
+    });
+
+    assert_eq!(resp.events.len(), 2);
+    assert_eq!(resp.events[0].unix_ts_ms, base_ms.saturating_sub(2));
+    assert_eq!(resp.events[1].unix_ts_ms, base_ms.saturating_sub(1));
+}

--- a/proxy/src/firewall/layer/evaluate_req.rs
+++ b/proxy/src/firewall/layer/evaluate_req.rs
@@ -31,11 +31,11 @@ where
                 .serve(req)
                 .await
                 .map_err(|err| OpaqueError::from_boxed(err.into())),
-            RequestAction::Block(resp) => {
+            RequestAction::Block(blocked) => {
                 tracing::trace!(
-                    "EvaluateRequestService: firewall blocked reuqest with self-generated response"
+                    "EvaluateRequestService: firewall blocked request with self-generated response"
                 );
-                Ok(resp)
+                Ok(blocked.response)
             }
         }
     }

--- a/proxy/src/firewall/rule/mod.rs
+++ b/proxy/src/firewall/rule/mod.rs
@@ -6,6 +6,13 @@ use rama::{
     net::address::Domain,
 };
 
+use super::events::BlockedEventInfo;
+
+pub struct BlockedRequest {
+    pub response: Response,
+    pub info: BlockedEventInfo,
+}
+
 pub use super::pac::PacScriptGenerator;
 
 pub mod chrome;
@@ -26,9 +33,10 @@ pub enum RequestAction {
     Allow(Request),
     /// Block the [`Request`] from proceeding to the next [`Rule`] or egress server.
     ///
-    /// Instead of proceeding the provided http [`Response`] will be returned to the
-    /// ingress client (e.g. the application wishing to downlod an extension).
-    Block(Response),
+    /// A [`BlockedRequest`] contains both the http [`Response`] to return to the ingress client
+    /// (e.g. the application wishing to download an extension) and [`BlockedEventInfo`] metadata
+    /// about what was blocked.
+    Block(BlockedRequest),
 }
 
 // NOTE: anything can implement this rule,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added blocked-events subsystem, /events endpoint, storage, and tests.

**⚡ Enhancements**
* Changed blocking flow to carry metadata via BlockedRequest and RequestAction.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/75325455?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->