### PR TITLE
Use http compression when downloading the malware databases

### DIFF
--- a/proxy/src/firewall/mod.rs
+++ b/proxy/src/firewall/mod.rs
@@ -8,7 +8,11 @@ use rama::{
         Body, HeaderValue, Request, Response,
         header::CONTENT_TYPE,
         layer::{
-            decompression::DecompressionLayer, map_request_body::MapRequestBodyLayer, map_response_body::MapResponseBodyLayer, retry::{ManagedPolicy, RetryLayer}, timeout::TimeoutLayer
+            decompression::DecompressionLayer,
+            map_request_body::MapRequestBodyLayer,
+            map_response_body::MapResponseBodyLayer,
+            retry::{ManagedPolicy, RetryLayer},
+            timeout::TimeoutLayer,
         },
         service::web::response::IntoResponse as _,
     },


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled HTTP response decompression when downloading remote malware databases

**🔧 Refactors**
* Reformatted firewall module file for consistent code style


<sup>[More info](https://app.aikido.dev/featurebranch/scan/76281976?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->