### PR TITLE
bump rust MSRV to 1.93

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to SafeChain Ultimate! This guide wi
 Before you begin, ensure you have the following installed:
 
 - **Go**: Version 1.25 or higher. You can download it from [golang.org](https://golang.org/).
-- **Rust**: Version 1.91 or higher. You can install it using [rustup](https://rustup.rs/).
+- **Rust**: Version 1.93 or higher. You can install it using [rustup](https://rustup.rs/).
 - **Make**: Typically pre-installed on Unix-like systems, used for building.
 - **Just**: You can install it via a package manager of choice: <https://just.systems/man/en/packages.html>
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -4,7 +4,7 @@ description = "MITM SafeChain HTTP(S)/SOCKS5 Proxy for Developer Security"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.91"
+rust-version = "1.93"
 readme = "../docs/proxy.md"
 resolver = "3"
 


### PR DESCRIPTION
musl targets improved and updated
bundled version to musl 1.2.5

Read More:
* https://github.com/rust-lang/rust/pull/142682
* https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/