### PR TITLE
update deps (incl fix windows boring def sys CAs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "rama"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "base64",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "rama-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "asynk-strim",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "rama-crypto"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2243,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "hickory-resolver",
@@ -2257,12 +2257,12 @@ dependencies = [
 [[package]]
 name = "rama-error"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 
 [[package]]
 name = "rama-grpc"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "base64",
  "flate2",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "rama-grpc-build"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2301,7 +2301,7 @@ dependencies = [
 [[package]]
 name = "rama-haproxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2312,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "rama-http"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "async-compression",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "rama-http-backend"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "rama-http-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "atomic-waker",
@@ -2393,7 +2393,7 @@ dependencies = [
 [[package]]
 name = "rama-http-headers"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "base64",
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "rama-http-types"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "bytes",
@@ -2443,7 +2443,7 @@ dependencies = [
 [[package]]
 name = "rama-macros"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "rama-net"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "const_format",
@@ -2475,7 +2475,7 @@ dependencies = [
  "rama-utils",
  "serde",
  "sha2",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "venndb",
 ]
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "rama-proxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "rama-socks5"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "byteorder",
  "rama-core",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "rama-tcp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-boring"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "brotli",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-rustls"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2575,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "rama-ua"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "ahash",
  "itertools 0.14.0",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "rama-udp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "rama-unix"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "rama-utils"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "const_format",
  "parking_lot",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "rama-ws"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=03e88f1ccdf260a8c9a3be16735198855ee44f44#03e88f1ccdf260a8c9a3be16735198855ee44f44"
+source = "git+https://github.com/plabayo/rama?rev=f3efc0820038515b146a95d3b668763be2cd23c1#f3efc0820038515b146a95d3b668763be2cd23c1"
 dependencies = [
  "flate2",
  "rama-core",
@@ -3167,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3421,7 +3421,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ resolver = "3"
 
 [workspace.dependencies.rama]
 git = "https://github.com/plabayo/rama"
-rev = "03e88f1ccdf260a8c9a3be16735198855ee44f44"
+rev = "f3efc0820038515b146a95d3b668763be2cd23c1"


### PR DESCRIPTION
The goal is to resolve the current TLS connector trust issues encountered on fresh Parallels Desktop Windows environments when connecting to Aikido malware certificates that rely on an Amazon IM CA.