### PR TITLE
Fix macOS build fail

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -62,7 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rust_cache_prefix: ""
           - arch: arm64
             target: aarch64-apple-darwin
             runner: macos-14


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added rust_cache_prefix entries for multiple CI matrix architectures.
* Set os: linux for unknown-linux-musl matrix entries to correctly identify.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/77949898?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->