### PR TITLE
add rule to forbid unwrap/expect for non-test code

### DIFF
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(
+    not(test),
+    warn(clippy::print_stdout, clippy::dbg_macro),
+    deny(clippy::unwrap_used, clippy::expect_used)
+)]
+
 use std::{path::PathBuf, time::Duration};
 
 use rama::{


### PR DESCRIPTION
and prevent outages such as cloudflare had
by ever using an unwrap/expect by accidant

should you still have an actual valid and desired
use-case of unwrap/expect you can explicitly allow that location using an `#[allow(...)]`  statement
on that location. Do this only if really desired
and with a very good documented reason attached to it.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added lint rule denying unwrap/expect and warning dbg/print in non-tests

**🐛 Bugfixes**
* Changed timestamp types and removed unwrap; handled negative unix timestamps safely


<sup>[More info](https://app.aikido.dev/featurebranch/scan/80658532?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->