### PR TITLE
env util addons improvements and related

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "safechain-proxy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "apple-native-keyring-store",
  "arc-swap",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "safechain-proxy"
 description = "MITM SafeChain HTTP(S)/SOCKS5 Proxy for Developer Security"
-version = "0.1.0"
+version = "1.0.0"  # keep in sync with GH releases
 edition = "2024"
 publish = false
 rust-version = "1.93"

--- a/proxy/src/firewall/mod.rs
+++ b/proxy/src/firewall/mod.rs
@@ -11,6 +11,7 @@ use rama::{
             decompression::DecompressionLayer,
             map_request_body::MapRequestBodyLayer,
             map_response_body::MapResponseBodyLayer,
+            required_header::AddRequiredRequestHeadersLayer,
             retry::{ManagedPolicy, RetryLayer},
             timeout::TimeoutLayer,
         },
@@ -32,7 +33,7 @@ pub mod version;
 
 mod pac;
 
-use crate::storage::SyncCompactDataStorage;
+use crate::{storage::SyncCompactDataStorage, utils::env::network_service_identifier};
 
 use self::rule::{RequestAction, Rule};
 
@@ -68,6 +69,9 @@ impl Firewall {
                     )
                     .context("create exponential backoff impl")?,
                 ),
+            ),
+            AddRequiredRequestHeadersLayer::new().with_user_agent_header_value(
+                HeaderValue::from_static(network_service_identifier()),
             ),
             MapRequestBodyLayer::new(Body::new),
         )

--- a/proxy/src/server/meta/mod.rs
+++ b/proxy/src/server/meta/mod.rs
@@ -82,8 +82,9 @@ pub async fn run_meta_https_server(
 
     let http_svc = (
         TraceLayer::new_for_http(),
-        AddRequiredResponseHeadersLayer::new()
-            .with_server_header_value(HeaderValue::from_static(crate::utils::env::project_name())),
+        AddRequiredResponseHeadersLayer::new().with_server_header_value(HeaderValue::from_static(
+            crate::utils::env::network_service_identifier(),
+        )),
     )
         .into_layer(http_router);
 

--- a/proxy/src/utils/env.rs
+++ b/proxy/src/utils/env.rs
@@ -1,3 +1,24 @@
 pub const fn project_name() -> &'static str {
     env!("CARGO_PKG_NAME")
 }
+
+pub const fn network_service_identifier() -> &'static str {
+    concat!(
+        "Aikido ",
+        env!("CARGO_PKG_NAME"),
+        "/",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+pub fn compute_concurrent_request_count() -> usize {
+    std::env::var("MAX_CONCURRENT_REQUESTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| {
+            let cpus = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1);
+            cpus * 64
+        })
+}


### PR DESCRIPTION
- have a common network identifier (user-agent / server name) used for non-proxy servers / clients to correctly identify the safe-chain proxy with its peers
- refactor the notifier util for getting the concurrent count to env so that it in future PRs can be reused
- add relevant layers to the notifier https client as it was still for no good reason a pretty barebone client so far

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added network_service_identifier constant and used it as User-Agent.
* Replaced bare notifier client with layered HTTPS client including retries.
* Updated firewall HTTP client to include User-Agent and required headers.

**🔧 Refactors**
* Moved compute_concurrent_request_count into env module for reuse.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/80662404?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->