### PR TITLE
fix concurrency of CI workflows

### DIFF
--- a/.github/workflows/build-macos-pkg.yml
+++ b/.github/workflows/build-macos-pkg.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-unix:
     uses: ./.github/workflows/build-unix.yml
@@ -59,7 +63,7 @@ jobs:
 
       - name: Make scripts executable
         run: chmod +x .github/scripts/macos/**/*.sh
-      
+
         # --- macOS signing + notarization (no entitlements for CLI) ---
       - name: Import macOS certificate
         env:

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-unix-agent:
     strategy:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-windows-ultimate:
     strategy:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   proxy-checks:
     strategy:


### PR DESCRIPTION
this ensures that if we are dealing with a PR
that a new commit will cancel the CI workflows of
the previous commit. Saving resources
and useless cycles

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled workflow concurrency to cancel previous PR runs on new commits


<sup>[More info](https://app.aikido.dev/featurebranch/scan/83323881?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->