### PR TITLE
Add package ID to SBOM for PIP implementation

### DIFF
--- a/internal/sbom/pip/sbom.go
+++ b/internal/sbom/pip/sbom.go
@@ -43,6 +43,7 @@ func (p *Pip) SBOM(ctx context.Context, installation sbom.InstalledVersion) ([]s
 	packages := make([]sbom.Package, 0, len(parsed))
 	for _, entry := range parsed {
 		packages = append(packages, sbom.Package{
+			Id:      entry.Name,
 			Name:    entry.Name,
 			Version: entry.Version,
 		})


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added package ID field to PIP SBOM package objects


<sup>[More info](https://app.aikido.dev/featurebranch/scan/87121249?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->