### PR TITLE
Rename block endpoint to allow more flexibility

### DIFF
--- a/internal/ingress/server.go
+++ b/internal/ingress/server.go
@@ -36,7 +36,7 @@ func (s *Server) Addr() string {
 
 func (s *Server) Start(ctx context.Context) error {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /block", s.handleBlock)
+	mux.HandleFunc("POST /events/blocks", s.handleBlock)
 	mux.HandleFunc("GET /ping", s.handlePing)
 	mux.HandleFunc("POST /request-bypass", s.handleRequestBypass)
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -83,7 +83,7 @@ func (p *Proxy) Start(ctx context.Context, proxyIngressAddr string) error {
 		"--data", platform.GetRunDir(),
 		"--output", filepath.Join(config.LogDir, platform.SafeChainL7ProxyLogName),
 		"--secrets", "keyring",
-		"--reporting-endpoint", fmt.Sprintf("http://%s/block", proxyIngressAddr),
+		"--reporting-endpoint", fmt.Sprintf("http://%s", proxyIngressAddr),
 	)
 
 	stderrLogPath := filepath.Join(config.LogDir, platform.SafeChainL7ProxyErrLogName)

--- a/proxy-bin-l7/src/client/mock_client/assert_endpoint.rs
+++ b/proxy-bin-l7/src/client/mock_client/assert_endpoint.rs
@@ -39,7 +39,7 @@ pub(super) fn web_svc(
 ) -> impl Service<Request, Output = Response, Error = Infallible> {
     Router::new_with_state(state)
         .with_get("/firewall-user-config/echo", safechain_config_echo)
-        .with_post("/blocked-events", record_blocked_event)
+        .with_post("/events/blocks", record_blocked_event)
         .with_get("/blocked-events/take", take_blocked_events)
         .with_get("/blocked-events/clear", clear_blocked_events)
 }

--- a/proxy-bin-l7/src/test/e2e/test_proxy/report_blocked_events.rs
+++ b/proxy-bin-l7/src/test/e2e/test_proxy/report_blocked_events.rs
@@ -20,11 +20,9 @@ async fn test_report_blocked_events_posts_json_to_endpoint() {
     assert_eq!(StatusCode::NO_CONTENT, resp.status());
 
     // Spawn a dedicated proxy instance so we can pass custom CLI flags.
-    let runtime = e2e::runtime::spawn_with_args(&[
-        "--reporting-endpoint",
-        "http://assert-test.internal/blocked-events",
-    ])
-    .await;
+    let runtime =
+        e2e::runtime::spawn_with_args(&["--reporting-endpoint", "http://assert-test.internal"])
+            .await;
 
     // Trigger a block, which should cause the notifier to emit one event.
     let client = runtime.client_with_http_proxy().await;
@@ -84,11 +82,9 @@ async fn test_report_blocked_events_dedupes_same_artifact_within_30s() {
         .unwrap();
     assert_eq!(StatusCode::NO_CONTENT, resp.status());
 
-    let runtime = e2e::runtime::spawn_with_args(&[
-        "--reporting-endpoint",
-        "http://assert-test.internal/blocked-events",
-    ])
-    .await;
+    let runtime =
+        e2e::runtime::spawn_with_args(&["--reporting-endpoint", "http://assert-test.internal"])
+            .await;
 
     let client = runtime.client_with_http_proxy().await;
     for _ in 0..2 {
@@ -137,11 +133,9 @@ async fn test_report_blocked_events_does_not_dedupe_different_versions_within_30
         .unwrap();
     assert_eq!(StatusCode::NO_CONTENT, resp.status());
 
-    let runtime = e2e::runtime::spawn_with_args(&[
-        "--reporting-endpoint",
-        "http://assert-test.internal/blocked-events",
-    ])
-    .await;
+    let runtime =
+        e2e::runtime::spawn_with_args(&["--reporting-endpoint", "http://assert-test.internal"])
+            .await;
 
     let client = runtime.client_with_http_proxy().await;
 

--- a/proxy-lib/src/http/firewall/notifier.rs
+++ b/proxy-lib/src/http/firewall/notifier.rs
@@ -159,12 +159,12 @@ async fn send_blocked_event(
         event.artifact
     );
 
-    let resp = match client
-        .post(reporting_endpoint.clone())
-        .json(&event)
-        .send()
-        .await
-    {
+    let url = format!(
+        "{}/events/blocks",
+        reporting_endpoint.to_string().trim_end_matches('/')
+    );
+
+    let resp = match client.post(&url).json(&event).send().await {
         Ok(resp) => resp,
         Err(err) => {
             tracing::warn!(


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Renamed ingress block endpoint to /events/blocks and handlers updated
* Changed proxy reporting endpoint to base URL and updated notifier/client


<sup>[More info](https://app.aikido.dev/featurebranch/scan/89041938?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->