### PR TITLE
Only show main window when clicking app bundle while running

### DIFF
--- a/ui/main.go
+++ b/ui/main.go
@@ -404,6 +404,14 @@ func main() {
 	statusCh := setupSystemTray(app, wm.showDashboard)
 	startAppServer(app, wm, statusCh, notifier)
 
+	// On macOS, clicking the app bundle while running triggers a default Wails
+	// listener that shows ALL hidden windows. Register a hook (runs before
+	// listeners and can cancel them) to show only the main window instead.
+	app.Event.RegisterApplicationEventHook(events.Mac.ApplicationShouldHandleReopen, func(event *application.ApplicationEvent) {
+		wm.showDashboard()
+		event.Cancel()
+	})
+
 	notifier.OnNotificationResponse(func(result notifications.NotificationResult) {
 		if result.Error != nil {
 			return


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Registered a FocusEventPayload event type for focus handling
* Emitted focus_event when opening dashboard from the system tray


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103582004?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->