### PR TITLE
fix: compare chrome blocks by PackageName only so dedup survives async DisplayName enrichment

### DIFF
--- a/internal/ingress/store.go
+++ b/internal/ingress/store.go
@@ -39,7 +39,7 @@ func (e *eventStore) MergeChromeBlockIfDuplicate(ev BlockEvent) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	for i := range e.events {
-		if e.events[i].Artifact == ev.Artifact {
+		if e.events[i].Artifact.PackageName == ev.Artifact.PackageName {
 			e.events[i].Count++
 			e.events[i].TsMs = ev.TsMs
 			return true


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Compared Chrome blocks by package name to fix deduplication


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103736288?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->