### PR TITLE
Drop desktop notification for TLS termination failures

### DIFF
--- a/ui/main.go
+++ b/ui/main.go
@@ -362,19 +362,6 @@ func startAppServer(app *application.App, wm *windowManager, statusCh chan<- app
 		func(ev daemon.TlsTerminationFailedEvent) {
 			log.Println("TLS termination failed event:", ev)
 			app.Event.Emit("tls_termination_failed", ev)
-			if authorized, _ := notifier.CheckNotificationAuthorization(); authorized {
-				body := "SNI: " + ev.SNI
-				if ev.App != "" {
-					body += " (" + ev.App + ")"
-				}
-				notifier.SendNotificationWithActions(notifications.NotificationOptions{
-					ID:         "tls-fail-" + ev.ID,
-					Title:      "TLS termination failed",
-					Body:       body,
-					CategoryID: "aikido-blocked",
-					Data:       map[string]interface{}{"eventId": ev.ID, "eventType": "tls"},
-				})
-			}
 		},
 		func(ev daemon.PermissionsResponse) {
 			log.Println("Permissions updated")


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed desktop notifications triggered by TLS termination failure events


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104073614?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->