### PR TITLE
Add system restart functionality for macOS and implement UI support

### DIFF
--- a/internal/ingress/restart_darwin.go
+++ b/internal/ingress/restart_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AikidoSec/safechain-internals/internal/platform"
+)
+
+func requestSystemRestart(ctx context.Context) error {
+	script := `tell application "System Events" to restart`
+	_, err := platform.RunInAuditSessionOfCurrentUser(ctx, "osascript", []string{"-e", script})
+	if err != nil {
+		return fmt.Errorf("failed to request system restart: %w", err)
+	}
+	return nil
+}

--- a/internal/ingress/restart_handler.go
+++ b/internal/ingress/restart_handler.go
@@ -1,0 +1,33 @@
+package ingress
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type restartResult struct {
+	Status string `json:"status"`
+}
+
+func (s *Server) handleSetupRestart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.validateUIToken(w, r) {
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := requestSystemRestart(r.Context()); err != nil {
+		log.Printf("ingress: system restart: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(restartResult{Status: "restarting"}); err != nil {
+		log.Printf("ingress: restart encode: %v", err)
+	}
+}

--- a/internal/ingress/restart_other.go
+++ b/internal/ingress/restart_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+)
+
+func requestSystemRestart(_ context.Context) error {
+	return fmt.Errorf("system restart is only supported on macOS")
+}

--- a/internal/ingress/server.go
+++ b/internal/ingress/server.go
@@ -92,6 +92,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	mux.HandleFunc("GET /v1/setup/check", s.handleSetupCheck)
 	mux.HandleFunc("POST /v1/setup/start", s.handleSetupStart)
+	mux.HandleFunc("POST /v1/setup/restart", s.handleSetupRestart)
 
 	listener, err := net.Listen("tcp", DefaultBind)
 	if err != nil {

--- a/ui/daemon/client.go
+++ b/ui/daemon/client.go
@@ -383,6 +383,19 @@ func SetupStart() error {
 	return nil
 }
 
+func SetupRestart() error {
+	resp, err := doRequest(http.MethodPost, "/v1/setup/restart", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("setup restart: %s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
 // RequestAccess sends POST /v1/events/:id/request-access
 func RequestAccess(eventID string) error {
 	if err := validateEventID(eventID); err != nil {

--- a/ui/daemonservice.go
+++ b/ui/daemonservice.go
@@ -90,6 +90,10 @@ func (s *DaemonService) SetInstallWindowOnTop(onTop bool) {
 	}
 }
 
+func (s *DaemonService) SetupRestart() error {
+	return daemon.SetupRestart()
+}
+
 // CloseInstallWindow hides the certificate install window.
 func (s *DaemonService) CloseInstallWindow() {
 	if closeInstallWindow != nil {

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -1381,6 +1381,65 @@ body {
   line-height: 1.6;
 }
 
+.install-page__restart-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.install-page__restart-btn {
+  background: #dc2626;
+  color: #fff;
+}
+
+.install-page__restart-btn:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.install-page__restart-btn:disabled {
+  opacity: 0.65;
+}
+
+.install-page__confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.install-page__confirm-dialog {
+  background: #fff;
+  border-radius: 14px;
+  padding: 28px 32px 24px;
+  max-width: 380px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+}
+
+.install-page__confirm-title {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #111827;
+}
+
+.install-page__confirm-body {
+  margin: 0 0 20px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: #4b5563;
+}
+
+.install-page__confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 .install-page__finish-bar {
   position: fixed;
   bottom: 0;

--- a/ui/frontend/src/api.ts
+++ b/ui/frontend/src/api.ts
@@ -71,6 +71,10 @@ export async function getSetupSteps(): Promise<string[]> {
   return DaemonService.GetSetupSteps();
 }
 
+export async function setupRestart(): Promise<void> {
+  return DaemonService.SetupRestart();
+}
+
 export async function closeInstallWindow(): Promise<void> {
   return DaemonService.CloseInstallWindow();
 }

--- a/ui/frontend/src/pages/InstallFinishPage.tsx
+++ b/ui/frontend/src/pages/InstallFinishPage.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { setupRestart } from "../api";
 import { getToolIcon } from "../constants";
 
 /** Icon layout: alternating left / right / center column; keys match `constants` TOOL_ICONS. */
@@ -13,8 +15,55 @@ const FINISH_ECOSYSTEM_VISUAL: { id: string; align: "left" | "right" | "center" 
 ];
 
 export function InstallFinishPage() {
+  const [restarting, setRestarting] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+
+  function handleRestartClick() {
+    setConfirming(true);
+  }
+
+  function handleCancel() {
+    setConfirming(false);
+  }
+
+  async function handleConfirm() {
+    setConfirming(false);
+    setRestarting(true);
+    try {
+      await setupRestart();
+    } catch {
+      setRestarting(false);
+    }
+  }
+
   return (
     <div className="install-page__main">
+      {confirming && (
+        <div className="install-page__confirm-overlay">
+          <div className="install-page__confirm-dialog">
+            <p className="install-page__confirm-title">Restart now?</p>
+            <p className="install-page__confirm-body">
+              Your system will restart immediately. Make sure you&apos;ve saved any open work.
+            </p>
+            <div className="install-page__confirm-actions">
+              <button
+                type="button"
+                className="button-brand button--tertiary button--normal button--rounded"
+                onClick={handleCancel}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="button-brand button--normal button--rounded install-page__restart-btn"
+                onClick={handleConfirm}
+              >
+                Restart
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <div className="install-page__finish-grid">
         <div className="install-page__finish-col install-page__finish-col--left">
           <div className="install-page__finish-hero install-page__finish-hero--split">
@@ -39,10 +88,21 @@ export function InstallFinishPage() {
             </div>
           </div>
           <div className="install-page__restart-card install-page__restart-card--emphasized">
-            <p className="install-page__restart-card-title">Restart apps if connections act up</p>
+            <p className="install-page__restart-card-title">System restart is highly recommended</p>
             <p className="install-page__restart-card-body">
-              If you experience connection issues in any running application, restarting it will resolve the problem.
+              A restart ensures all applications pick up the new certificate and network settings. You can restart now or
+              do it later from your system menu.
             </p>
+            <div className="install-page__restart-card-actions">
+              <button
+                type="button"
+                className="button-brand button--normal button--rounded install-page__restart-btn"
+                disabled={restarting}
+                onClick={handleRestartClick}
+              >
+                {restarting ? "Restarting…" : "Restart"}
+              </button>
+            </div>
           </div>
         </div>
 

--- a/ui/mock/main.go
+++ b/ui/mock/main.go
@@ -384,6 +384,11 @@ func (s *server) handleSetupStart(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, map[string][]string{"steps": steps})
 }
 
+func (s *server) handleSetupRestart(w http.ResponseWriter, r *http.Request) {
+	log.Printf("mock: setup restart")
+	s.writeJSON(w, map[string]string{"status": "restarting"})
+}
+
 func main() {
 	blocks, tlsEvents := seedData()
 	s := &server{blocks: blocks, tlsEvents: tlsEvents, permissions: seedPermissions()}
@@ -411,6 +416,7 @@ func main() {
 
 	mux.HandleFunc("GET /v1/setup/check", s.handleSetupCheck)
 	mux.HandleFunc("POST /v1/setup/start", s.handleSetupStart)
+	mux.HandleFunc("POST /v1/setup/restart", s.handleSetupRestart)
 
 	addr := "127.0.0.1:7878"
 	fmt.Printf("Mock daemon listening on %s\n", addr)


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented macOS system restart API and platform-specific request handlers

**⚡ Enhancements**
* Exposed restart through daemon service and added UI confirmation dialog


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104148734?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

<img width="913" height="706" alt="image" src="https://github.com/user-attachments/assets/5ea75e8e-7269-4698-aa16-1857a0309c45" />

<img width="875" height="598" alt="image" src="https://github.com/user-attachments/assets/153b35d9-2a04-4f61-baf7-e6e31e3c9963" />

