### PR TITLE
Add extra logs while setting up the firewall for a request

### DIFF
--- a/proxy-lib/src/http/firewall/mod.rs
+++ b/proxy-lib/src/http/firewall/mod.rs
@@ -315,8 +315,21 @@ impl Firewall {
             .collect();
 
         if matched_rules.is_empty() {
+            tracing::debug!(
+                domain = %incoming_flow_info.domain,
+                bundle_id = %incoming_flow_info.app_bundle_id.unwrap_or("default"),
+                source_process_path = ?incoming_flow_info.source_process_path,
+                "skipping firewall because no rules matched"
+            );
             None
         } else {
+            let num_rules = matched_rules.len();
+            tracing::debug!(
+                domain = %incoming_flow_info.domain,
+                bundle_id = %incoming_flow_info.app_bundle_id.unwrap_or("default"),
+                source_process_path = ?incoming_flow_info.source_process_path,
+                "setting up firewall for {num_rules} rules"
+            );
             Some(FirewallHttpRules(matched_rules))
         }
     }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added extra logging during firewall setup for incoming requests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104592136?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->