### PR TITLE
Fix: pypi rewrite should not drop the encoding headers

### DIFF
--- a/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
@@ -4,9 +4,9 @@ use rama::{
         Body, Response,
         body::util::BodyExt as _,
         headers::{CacheControl, ContentType, HeaderMapExt as _},
+        header,
         layer::remove_header::{
             remove_cache_policy_headers, remove_cache_validation_response_headers,
-            remove_payload_metadata_headers,
         },
     },
     telemetry::tracing,
@@ -111,7 +111,7 @@ impl MinPackageAgePyPI {
     fn make_uncacheable(headers: &mut rama::http::HeaderMap) {
         remove_cache_policy_headers(headers);
         remove_cache_validation_response_headers(headers);
-        remove_payload_metadata_headers(headers);
+        headers.remove(header::CONTENT_LENGTH);
         headers.typed_insert(CacheControl::new().with_no_cache());
     }
 

--- a/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
@@ -3,8 +3,8 @@ use rama::{
     http::{
         Body, Response,
         body::util::BodyExt as _,
-        headers::{CacheControl, ContentType, HeaderMapExt as _},
         header,
+        headers::{CacheControl, ContentType, HeaderMapExt as _},
         layer::remove_header::{
             remove_cache_policy_headers, remove_cache_validation_response_headers,
         },


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Adjusted uncacheable header removal to only drop Content-Length header

**🔧 Refactors**
* Imported header module and reformatted imports and spacing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/105713103?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->