### PR TITLE
fix(ui): set request_pending on all events for same artifact

### DIFF
--- a/internal/ingress/request_bypass_handler.go
+++ b/internal/ingress/request_bypass_handler.go
@@ -20,7 +20,12 @@ func (s *Server) handleRequestBypass(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("Received request-bypass event: name=%s, version=%s, product=%s", event.Artifact.PackageName, event.Artifact.PackageVersion, event.Artifact.Product)
-	s.eventStore.UpdateStatus(id, "request_pending")
+
+	for _, e := range s.eventStore.List() {
+		if e.Artifact == event.Artifact {
+			s.eventStore.UpdateStatus(e.ID, "request_pending")
+		}
+	}
 
 	go s.sendInstallationRequest(event)
 


### PR DESCRIPTION
When the user requests installation from one blocked row, any other stored events for the same artifact are updated to `request_pending` so the UI does not show inconsistent duplicate entries.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


No summary available


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106100871?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->