### PR TITLE
update deps + adapt to new rama API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,11 +1445,12 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.46"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1577,9 +1578,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.49"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -434,7 +434,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -554,11 +554,12 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -836,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1105,7 +1106,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1135,6 +1136,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1213,12 +1220,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1366,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1384,6 +1391,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,9 +1419,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1423,12 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -1538,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "md5"
@@ -1556,9 +1577,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1867,9 +1888,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1879,9 +1900,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2064,9 +2085,9 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psl"
-version = "2.1.200"
+version = "2.1.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeecfb788a39437717879e1055237308caaa520a0041bb9536899dff28bf24a6"
+checksum = "868e3200a2474f99d0ea576a7c76aabda7cdcc795cc27f2d93f30ab79867820d"
 dependencies = [
  "psl-types",
 ]
@@ -2111,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "rama"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "base64",
@@ -2186,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "rama-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "asynk-strim",
@@ -2210,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "rama-crypto"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2226,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "bindgen 0.72.1",
@@ -2237,7 +2258,7 @@ dependencies = [
  "rama-core",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
  "windows-sys 0.61.2",
 ]
@@ -2245,12 +2266,12 @@ dependencies = [
 [[package]]
 name = "rama-error"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 
 [[package]]
 name = "rama-grpc"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2275,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "rama-grpc-build"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2291,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "rama-haproxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2302,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "rama-http"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "async-compression",
@@ -2327,7 +2348,7 @@ dependencies = [
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rawzip",
  "serde",
  "serde_html_form",
@@ -2339,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "rama-http-backend"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2358,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "rama-http-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "atomic-waker",
@@ -2383,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "rama-http-headers"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "base64",
@@ -2395,7 +2416,7 @@ dependencies = [
  "rama-macros",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "sha1",
 ]
@@ -2403,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "rama-http-types"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "bytes",
@@ -2421,7 +2442,7 @@ dependencies = [
  "rama-core",
  "rama-macros",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -2431,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "rama-macros"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2442,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "rama-net"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "const_format",
@@ -2474,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "libc",
  "parking_lot",
@@ -2491,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "rama-proxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2507,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "rama-socks5"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "byteorder",
  "rama-core",
@@ -2522,22 +2543,23 @@ dependencies = [
 [[package]]
 name = "rama-tcp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
+ "libc",
  "pin-project-lite",
  "rama-core",
  "rama-dns",
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
 ]
 
 [[package]]
 name = "rama-tls-boring"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "brotli",
@@ -2562,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-rustls"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2582,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "rama-ua"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "ahash",
  "itertools 0.14.0",
@@ -2590,7 +2612,7 @@ dependencies = [
  "rama-http",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -2599,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "rama-udp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "rama-core",
  "rama-dns",
@@ -2611,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "rama-unix"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2623,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "rama-utils"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "const_format",
  "parking_lot",
@@ -2640,22 +2662,22 @@ dependencies = [
 [[package]]
 name = "rama-ws"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=59f6863b01f4eeaf6afc32208a95081415ef3196#59f6863b01f4eeaf6afc32208a95081415ef3196"
+source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
 dependencies = [
  "flate2",
  "rama-core",
  "rama-http",
  "rama-net",
  "rama-utils",
- "rand 0.10.0",
+ "rand 0.10.1",
  "tokio",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2663,13 +2685,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2693,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rawzip"
@@ -2808,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2871,9 +2893,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2994,7 +3016,7 @@ dependencies = [
  "postcard",
  "radix_trie",
  "rama",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustls-platform-verifier",
  "safechain-proxy-lib-nostd",
  "secrecy",
@@ -3326,6 +3348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,9 +3517,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3585,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3617,12 +3645,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "parking_lot",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -3738,9 +3767,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -3789,9 +3818,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3817,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "027cbaacc64ede3aec4ad7a8d234bee0e440c23eed3f61e2f5a83784900ed33a"
 dependencies = [
  "hashbrown 0.16.1",
- "rand 0.9.2",
+ "rand 0.9.4",
  "venndb-macros",
 ]
 
@@ -3865,11 +3894,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3878,14 +3907,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3896,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3906,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3919,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4054,18 +4083,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4376,6 +4405,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libfuzzer-sys = "0.4"
 linux-keyutils-keyring-store = "0.2"
 lol_html = "2"
 lz4_flex = "0.13"
-mimalloc = { version = "0.1", default-features = false }
+mimalloc = { version = "=0.1.48", default-features = false }
 moka = "0.12"
 parking_lot = "0.12.5"
 postcard = { version = "1.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ rust-version = "1.93"
 
 [workspace.dependencies]
 apple-native-keyring-store = "0.2"
-arc-swap = "1.7"
+arc-swap = "1.9"
 bindgen = "0.71"
-clap = { version = "4.5" }
+clap = { version = "4.6" }
 humantime = "2.3"
 jemallocator = { package = "tikv-jemallocator", version = "0.6" }
 keyring-core = "0.7"
@@ -47,7 +47,7 @@ spin = "0.9"
 static_vcruntime = "3.0"
 sudo = "0.6"
 sync_wrapper = "1"
-tokio = { version = "1.48" }
+tokio = { version = "1.52" }
 tracing-oslog = "0.3"
 tracing-subscriber = "0.3"
 tracing-test = "0.2"
@@ -61,11 +61,11 @@ windows-sys = "0.61"
 
 [workspace.dependencies.rama]
 git = "https://github.com/plabayo/rama"
-rev = "59f6863b01f4eeaf6afc32208a95081415ef3196"
+rev = "d4d9a69c2e7be138580a6e259ee260f78e38c005"
 
 [workspace.dependencies.rama-core]
 git = "https://github.com/plabayo/rama"
-rev = "59f6863b01f4eeaf6afc32208a95081415ef3196"
+rev = "d4d9a69c2e7be138580a6e259ee260f78e38c005"
 
 [profile.release]
 strip = true

--- a/justfile
+++ b/justfile
@@ -135,8 +135,9 @@ clean-packaging:
 clean: clean-rust clean-xcode clean-packaging
 
 rust-update-deps:
+    @cargo install cargo-edit
+    cargo upgrade
     cargo update
-    cargo outdated
 
 rust-detect-unused-deps:
     @cargo install cargo-machete

--- a/packaging/macos/xcode/l4-proxy/Project.dev.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dev.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: 59f6863b01f4eeaf6afc32208a95081415ef3196
+    revision: d4d9a69c2e7be138580a6e259ee260f78e38c005
 
 targets:
   AikidoNetworkExtensionHost:

--- a/packaging/macos/xcode/l4-proxy/Project.dist.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dist.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: 59f6863b01f4eeaf6afc32208a95081415ef3196
+    revision: d4d9a69c2e7be138580a6e259ee260f78e38c005
 
 targets:
   AikidoNetworkExtensionHost:

--- a/proxy-bin-l4/src/tcp/mod.rs
+++ b/proxy-bin-l4/src/tcp/mod.rs
@@ -4,7 +4,7 @@ use rama::{
     Layer, Service,
     combinators::Either,
     error::{BoxError, ErrorContext as _},
-    extensions::ExtensionsMut,
+    extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     http::{
         Request, Response, Uri,
@@ -206,8 +206,8 @@ fn new_tcp_service_inner<Issuer, Ingress, Egress>(
 ) -> impl Service<BridgeIo<Ingress, Egress>, Output = (), Error = Infallible> + Clone
 where
     Issuer: BoringMitmCertIssuer<Error: Into<BoxError>> + Clone,
-    Ingress: Io + Unpin + ExtensionsMut,
-    Egress: Io + Unpin + ExtensionsMut,
+    Ingress: Io + Unpin + ExtensionsRef,
+    Egress: Io + Unpin + ExtensionsRef,
 {
     let http_mitm_svc =
         HttpMitmRelay::new(exec.clone()).with_http_middleware(http_relay_middleware(

--- a/proxy-bin-l4/src/tcp/proxy_target/deny.rs
+++ b/proxy-bin-l4/src/tcp/proxy_target/deny.rs
@@ -1,4 +1,4 @@
-use rama::{Layer, Service, error::BoxError, extensions::ExtensionsMut, io::Io};
+use rama::{Layer, Service, error::BoxError, extensions::ExtensionsRef, io::Io};
 
 #[derive(Debug, Clone)]
 pub struct DenyProxyTargetFromInputLayer;
@@ -22,7 +22,7 @@ impl<S> Layer<S> for DenyProxyTargetFromInputLayer {
 impl<S, Input> Service<Input> for DenyProxyTargetFromInput<S>
 where
     S: Service<Input, Error: Into<BoxError>>,
-    Input: Io + ExtensionsMut,
+    Input: Io + ExtensionsRef,
 {
     type Output = S::Output;
     type Error = BoxError;

--- a/proxy-bin-l4/src/tcp/proxy_target/windows.rs
+++ b/proxy-bin-l4/src/tcp/proxy_target/windows.rs
@@ -7,7 +7,7 @@ use std::{
 use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext as _},
-    extensions::ExtensionsMut,
+    extensions::ExtensionsRef,
     net::proxy::ProxyTarget,
     telemetry::tracing,
 };
@@ -90,7 +90,7 @@ pub struct ProxyTargetFromWfpContext<S, D> {
 impl<S, Input, D> Service<Input> for ProxyTargetFromWfpContext<S, D>
 where
     S: Service<Input, Error: Into<BoxError>>,
-    Input: AsRawSocket + ExtensionsMut + Send + 'static,
+    Input: AsRawSocket + ExtensionsRef + Send + 'static,
     D: WfpContextDecoder,
 {
     type Output = S::Output;

--- a/proxy-bin-l4/src/tcp/proxy_target/windows.rs
+++ b/proxy-bin-l4/src/tcp/proxy_target/windows.rs
@@ -2,6 +2,7 @@ use std::{
     fmt, io,
     os::windows::io::{AsRawSocket, RawSocket},
     ptr,
+    sync::Arc,
 };
 
 use rama::{
@@ -11,6 +12,10 @@ use rama::{
     net::proxy::ProxyTarget,
     telemetry::tracing,
 };
+use safechain_proxy_lib::{
+    nostd::windows::redirect_ctx::ProxyRedirectContext, utils::net::ProxyRedirectContextExt,
+};
+
 use windows_sys::Win32::{
     Foundation::ERROR_INSUFFICIENT_BUFFER,
     Networking::WinSock::{
@@ -91,12 +96,12 @@ impl<S, Input, D> Service<Input> for ProxyTargetFromWfpContext<S, D>
 where
     S: Service<Input, Error: Into<BoxError>>,
     Input: AsRawSocket + ExtensionsRef + Send + 'static,
-    D: WfpContextDecoder,
+    D: WfpContextDecoder<Context = ProxyRedirectContext>,
 {
     type Output = S::Output;
     type Error = BoxError;
 
-    async fn serve(&self, mut input: Input) -> Result<Self::Output, Self::Error> {
+    async fn serve(&self, input: Input) -> Result<Self::Output, Self::Error> {
         let context_bytes = match query_wfp_redirect_context(input.as_raw_socket())
             .context("query WFP context from input stream")?
         {
@@ -122,8 +127,10 @@ where
             .decode(&context_bytes)
             .context("decode WFP context")?;
 
-        input.extensions_mut().insert(context);
-        input.extensions_mut().insert(proxy_target);
+        input
+            .extensions()
+            .insert(ProxyRedirectContextExt(Arc::new(context)));
+        input.extensions().insert(proxy_target);
 
         self.inner
             .serve(input)

--- a/proxy-bin-l7/src/client/mock_server/mod.rs
+++ b/proxy-bin-l7/src/client/mock_server/mod.rs
@@ -7,7 +7,7 @@ use rama::{
     Layer, Service,
     cli::service::echo::EchoServiceBuilder,
     error::BoxError,
-    extensions::ExtensionsMut,
+    extensions::ExtensionsRef,
     http::{
         Request, Response,
         layer::{
@@ -55,7 +55,7 @@ pub fn new_mock_tcp_connector<Input>(
 ) -> impl ConnectorService<Input, Connection: Io + Unpin> + Clone
 where
     Input:
-        ExtensionsMut + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
+        ExtensionsRef + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
     BoxError: From<Input::Error>,
 {
     // Use an in-memory duplex stream pair instead of binding a real TCP socket.

--- a/proxy-bin-l7/src/server/proxy/auth/mod.rs
+++ b/proxy-bin-l7/src/server/proxy/auth/mod.rs
@@ -23,14 +23,14 @@ impl ZeroAuthority {
 }
 
 impl<T: UsernameLabelParser> AuthoritySync<Basic, T> for ZeroAuthority {
-    fn authorized(&self, ext: &mut Extensions, credentials: &Basic) -> bool {
+    fn authorized(&self, ext: &Extensions, credentials: &Basic) -> bool {
         let basic_username = credentials.username();
         tracing::trace!("ZeroAuthority (http proxy) trusts all, it also trusts: {basic_username}");
 
-        let mut parser_ext = Extensions::new();
-        let parsed_username = match parse_username(&mut parser_ext, T::default(), basic_username) {
+        let parser_ext = Extensions::new();
+        let parsed_username = match parse_username(&parser_ext, T::default(), basic_username) {
             Ok(t) => {
-                ext.extend(parser_ext);
+                ext.extend(&parser_ext);
                 t
             }
             Err(err) => {
@@ -52,7 +52,7 @@ impl Authorizer<Basic> for ZeroAuthority {
             "ZeroAuthority (socks5 proxy) trusts all, it also trusts: {basic_username}"
         );
 
-        let mut result_extensions = Extensions::new();
+        let result_extensions = Extensions::new();
         result_extensions.insert(UserId::Username(basic_username.to_owned()));
 
         AuthorizeResult {

--- a/proxy-bin-l7/src/server/proxy/server.rs
+++ b/proxy-bin-l7/src/server/proxy/server.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, sync::Arc};
 use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext as _},
-    extensions::ExtensionsMut,
+    extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     http::{
         Request, Response,
@@ -50,7 +50,7 @@ use safechain_proxy_lib::{
     tls::{RootCaKeyPair, mitm_relay_policy::TlsMitmRelayPolicyLayer},
 };
 
-pub(super) fn new_app_mitm_server<S: Io + ExtensionsMut + Unpin>(
+pub(super) fn new_app_mitm_server<S: Io + ExtensionsRef + Unpin>(
     guard: ShutdownGuard,
     mitm_all: bool,
     root_ca: RootCaKeyPair,

--- a/proxy-lib-l4-macos/Cargo.toml
+++ b/proxy-lib-l4-macos/Cargo.toml
@@ -19,7 +19,7 @@ rustls-platform-verifier = { workspace = true }
 safechain-proxy-lib = { workspace = true, features = ["apple-networkextension"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true }
-tokio = { version = "1.48", features = ["net", "io-std"] }
+tokio = { version = "1.52", features = ["net", "io-std"] }
 tracing-oslog = { workspace = true }
 
 [dependencies.rama]

--- a/proxy-lib-l4-macos/src/handler.rs
+++ b/proxy-lib-l4-macos/src/handler.rs
@@ -1,0 +1,242 @@
+use std::{convert::Infallible, future::Future};
+
+use rama::{
+    Service,
+    error::BoxError,
+    net::{
+        address::{Host, HostWithPort},
+        apple::networkextension::{
+            TcpFlow, UdpFlow,
+            tproxy::{
+                FlowAction, TransparentProxyConfig, TransparentProxyFlowAction,
+                TransparentProxyFlowMeta, TransparentProxyFlowProtocol, TransparentProxyHandler,
+                TransparentProxyHandlerFactory, TransparentProxyNetworkRule,
+                TransparentProxyRuleProtocol, TransparentProxyServiceContext,
+            },
+        },
+    },
+    rt::Executor,
+    service::BoxService,
+    telemetry::tracing,
+    utils::str::any_starts_with_ignore_ascii_case,
+};
+use safechain_proxy_lib::nostd::net::is_passthrough_ip;
+
+type UdpFlowService = BoxService<UdpFlow, (), Infallible>;
+
+#[derive(Debug, Clone)]
+pub struct FlowHandlerFactory;
+
+#[derive(Clone)]
+pub struct FlowHandler {
+    config: TransparentProxyConfig,
+    tcp_mitm_service: crate::tcp::TcpMitmService,
+}
+
+impl FlowHandler {
+    async fn try_new(ctx: TransparentProxyServiceContext) -> Result<Self, BoxError> {
+        let tcp_mitm_service = crate::tcp::TcpMitmService::try_new(ctx).await?;
+
+        let proxy_config = TransparentProxyConfig::new().with_rules(vec![
+            TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Tcp),
+            TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Udp),
+        ]);
+
+        Ok(Self {
+            config: proxy_config,
+            tcp_mitm_service,
+        })
+    }
+}
+
+impl TransparentProxyHandlerFactory for FlowHandlerFactory {
+    type Handler = FlowHandler;
+    type Error = BoxError;
+
+    fn create_transparent_proxy_handler(
+        &self,
+        ctx: TransparentProxyServiceContext,
+    ) -> impl Future<Output = Result<Self::Handler, Self::Error>> + Send {
+        FlowHandler::try_new(ctx)
+    }
+}
+
+impl TransparentProxyHandler for FlowHandler {
+    fn transparent_proxy_config(&self) -> TransparentProxyConfig {
+        self.config.clone()
+    }
+
+    fn match_tcp_flow(
+        &self,
+        exec: Executor,
+        meta: TransparentProxyFlowMeta,
+    ) -> impl Future<Output = FlowAction<impl Service<TcpFlow, Output = (), Error = Infallible>>>
+    + Send
+    + '_ {
+        std::future::ready(match flow_action(&meta) {
+            TransparentProxyFlowAction::Intercept => FlowAction::Intercept {
+                service: self.tcp_mitm_service.new_intercept_service(exec),
+                meta,
+            },
+            TransparentProxyFlowAction::Passthrough => FlowAction::Passthrough,
+            TransparentProxyFlowAction::Blocked => FlowAction::Blocked,
+        })
+    }
+
+    fn match_udp_flow(
+        &self,
+        _exec: Executor,
+        meta: TransparentProxyFlowMeta,
+    ) -> impl Future<Output = FlowAction<impl Service<UdpFlow, Output = (), Error = Infallible>>>
+    + Send
+    + '_ {
+        std::future::ready(match flow_action(&meta) {
+            TransparentProxyFlowAction::Intercept => {
+                tracing::warn!(
+                    protocol = ?meta.protocol,
+                    remote = ?meta.remote_endpoint,
+                    local = ?meta.local_endpoint,
+                    "unexpected udp intercept decision; passing through"
+                );
+                FlowAction::<UdpFlowService>::Passthrough
+            }
+            TransparentProxyFlowAction::Passthrough => FlowAction::<UdpFlowService>::Passthrough,
+            TransparentProxyFlowAction::Blocked => FlowAction::<UdpFlowService>::Blocked,
+        })
+    }
+}
+
+fn flow_action(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
+    tracing::debug!(
+        protocol = ?meta.protocol,
+        remote = ?meta.remote_endpoint,
+        local = ?meta.local_endpoint,
+        app_bundle_id = ?meta.source_app_bundle_identifier,
+        app_sign_id = ?meta.source_app_signing_identifier,
+        "flow intercept decision: evaluating"
+    );
+
+    let Some(remote_host) = remote_host_for_interception(meta) else {
+        return TransparentProxyFlowAction::Passthrough;
+    };
+
+    match meta.protocol {
+        TransparentProxyFlowProtocol::Tcp => {
+            tracing::debug!(
+                protocol = ?meta.protocol,
+                remote = ?meta.remote_endpoint,
+                local = ?meta.local_endpoint,
+                app_bundle_id = ?meta.source_app_bundle_identifier,
+                app_sign_id = ?meta.source_app_signing_identifier,
+                "flow action: tcp traffic: intercept"
+            );
+            TransparentProxyFlowAction::Intercept
+        }
+        TransparentProxyFlowProtocol::Udp => flow_action_udp(meta, remote_host),
+    }
+}
+
+fn flow_action_udp(
+    meta: &TransparentProxyFlowMeta,
+    remote_host: HostWithPort,
+) -> TransparentProxyFlowAction {
+    if remote_host.port != 443 {
+        tracing::debug!(
+            protocol = ?meta.protocol,
+            remote = ?meta.remote_endpoint,
+            local = ?meta.local_endpoint,
+            app_bundle_id = ?meta.source_app_bundle_identifier,
+            app_sign_id = ?meta.source_app_signing_identifier,
+            "flow action: udp traffic with port != 443: passthrough"
+        );
+        return TransparentProxyFlowAction::Passthrough;
+    }
+
+    if meta
+        .source_app_bundle_identifier
+        .as_deref()
+        .map(is_chromium_bundle_identifier)
+        .unwrap_or(false)
+    {
+        tracing::debug!(
+            protocol = ?meta.protocol,
+            remote = ?meta.remote_endpoint,
+            local = ?meta.local_endpoint,
+            app_bundle_id = ?meta.source_app_bundle_identifier,
+            app_sign_id = ?meta.source_app_signing_identifier,
+            "flow action: udp traffic on port 443 for chromium browser: block"
+        );
+        return TransparentProxyFlowAction::Blocked;
+    }
+
+    tracing::debug!(
+        protocol = ?meta.protocol,
+        remote = ?meta.remote_endpoint,
+        local = ?meta.local_endpoint,
+        app_bundle_id = ?meta.source_app_bundle_identifier,
+        app_sign_id = ?meta.source_app_signing_identifier,
+        "flow action: udp traffic on port 443 for non-chromium app: passthrough"
+    );
+    TransparentProxyFlowAction::Passthrough
+}
+
+fn remote_host_for_interception(meta: &TransparentProxyFlowMeta) -> Option<HostWithPort> {
+    let Some(target) = meta.remote_endpoint.as_ref() else {
+        tracing::debug!(
+            protocol = ?meta.protocol,
+            remote = ?meta.remote_endpoint,
+            local = ?meta.local_endpoint,
+            app_bundle_id = ?meta.source_app_bundle_identifier,
+            app_sign_id = ?meta.source_app_signing_identifier,
+            "remote host is missing: passthrough traffic"
+        );
+        return None;
+    };
+
+    match &target.host {
+        Host::Name(_) => Some(target.clone()),
+        Host::Address(addr) => {
+            if is_passthrough_ip(*addr) {
+                tracing::debug!(
+                    protocol = ?meta.protocol,
+                    remote = ?meta.remote_endpoint,
+                    local = ?meta.local_endpoint,
+                    app_bundle_id = ?meta.source_app_bundle_identifier,
+                    app_sign_id = ?meta.source_app_signing_identifier,
+                    "remote host is within passthrough IP range: passthrough traffic"
+                );
+                None
+            } else {
+                Some(target.clone())
+            }
+        }
+    }
+}
+
+fn is_chromium_bundle_identifier(identifier: &str) -> bool {
+    any_starts_with_ignore_ascii_case(
+        identifier,
+        [
+            // Google Chrome
+            "com.google.chrome",
+            // Chromium and forks that reuse upstream id
+            "org.chromium",
+            // Microsoft Edge
+            "com.microsoft.edgemac",
+            "com.microsoft.msedge",
+            // Brave
+            "com.brave.browser",
+            "com.brave.ios",
+            // Opera
+            "com.operasoftware.opera",
+            // Vivaldi
+            "com.vivaldi",
+            // Arc
+            "company.thebrowser",
+            // Yandex
+            "ru.yandex",
+            // Common alt Chromium builds
+            "com.github.eloston", // ungoogled chromium
+        ],
+    )
+}

--- a/proxy-lib-l4-macos/src/init.rs
+++ b/proxy-lib-l4-macos/src/init.rs
@@ -1,0 +1,31 @@
+use rama::{
+    net::apple::networkextension::ffi::tproxy::TransparentProxyInitConfig, telemetry::tracing,
+};
+
+pub(super) fn init(config: Option<&TransparentProxyInitConfig>) -> bool {
+    if !crate::utils::init_tracing() {
+        return false;
+    }
+
+    if let Some(config) = config {
+        // SAFETY: pointer + length validity is guaranteed by FFI contract.
+        if let Some(path) = unsafe { config.storage_dir() } {
+            tracing::debug!(path = %path.display(), "received storage directory: pass to set_storage_dir");
+            crate::utils::storage::set_storage_dir(Some(path));
+        }
+        // SAFETY: pointer + length validity is guaranteed by FFI contract.
+        if let Some(app_group_dir) = unsafe { config.app_group_dir() } {
+            tracing::debug!(path = %app_group_dir.display(), "received app-group directory");
+        }
+    }
+
+    const FD_LIMIT: rama::unix::utils::rlim_t = 262_144;
+    if let Err(err) = rama::unix::utils::raise_nofile(FD_LIMIT) {
+        tracing::warn!("failed to increase FD limit for L4 (t)proxy: {err}");
+    } else {
+        tracing::info!("increased FD limit for L4 (t)proxy to: {FD_LIMIT}");
+    }
+
+    tracing::info!("aikido L4 proxy initialized");
+    true
+}

--- a/proxy-lib-l4-macos/src/lib.rs
+++ b/proxy-lib-l4-macos/src/lib.rs
@@ -1,208 +1,21 @@
 #![cfg(target_os = "macos")]
 
-use rama::{
-    net::{
-        address::{Host, HostWithPort},
-        apple::networkextension::{
-            self as apple_ne,
-            tproxy::{
-                TransparentProxyConfig, TransparentProxyFlowAction, TransparentProxyFlowMeta,
-                TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
-                TransparentProxyRuleProtocol,
-            },
-        },
-    },
-    telemetry::tracing,
-    utils::str::any_starts_with_ignore_ascii_case,
+use rama::net::apple::networkextension::{
+    tproxy::TransparentProxyEngineBuilder, transparent_proxy_ffi,
 };
-
-use safechain_proxy_lib::nostd::net::is_passthrough_ip;
 
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 mod config;
+mod handler;
+mod init;
 mod tcp;
 mod utils;
 
-fn init(config: Option<&apple_ne::ffi::tproxy::TransparentProxyInitConfig>) -> bool {
-    if !self::utils::init_tracing() {
-        return false;
-    }
-
-    if let Some(config) = config {
-        // SAFETY: pointer + length validity is guaranteed by FFI contract.
-        if let Some(path) = unsafe { config.storage_dir() } {
-            tracing::debug!(path = %path.display(), "received storage directory: pass to set_storage_dir");
-            self::utils::storage::set_storage_dir(Some(path));
-        }
-        // SAFETY: pointer + length validity is guaranteed by FFI contract.
-        if let Some(app_group_dir) = unsafe { config.app_group_dir() } {
-            tracing::debug!(path = %app_group_dir.display(), "received app-group directory");
-        }
-    }
-
-    const FD_LIMIT: rama::unix::utils::rlim_t = 262_144;
-    if let Err(err) = rama::unix::utils::raise_nofile(FD_LIMIT) {
-        tracing::warn!("failed to increase FD limit for L4 (t)proxy: {err}");
-    } else {
-        tracing::info!("increased FD limit for L4 (t)proxy to: {FD_LIMIT}");
-    }
-
-    tracing::info!("aikido L4 proxy initialized");
-    true
-}
-
-fn proxy_config() -> TransparentProxyConfig {
-    TransparentProxyConfig::new().with_rules(vec![
-        TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Tcp),
-        TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Udp),
-    ])
-}
-
-fn flow_action(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
-    tracing::debug!(
-        protocol = ?meta.protocol,
-        remote = ?meta.remote_endpoint,
-        local = ?meta.local_endpoint,
-        app_bundle_id = ?meta.source_app_bundle_identifier,
-        app_sign_id = ?meta.source_app_signing_identifier,
-        "flow intercept decision: evaluating (rust callback entered)"
-    );
-
-    let Some(remote_host) = is_ip_remote_host_passthrough(meta) else {
-        return TransparentProxyFlowAction::Passthrough;
-    };
-
-    match meta.protocol {
-        TransparentProxyFlowProtocol::Tcp => flow_action_tcp(meta),
-        TransparentProxyFlowProtocol::Udp => flow_action_udp(meta, remote_host),
-    }
-}
-
-fn flow_action_tcp(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
-    tracing::debug!(
-        protocol = ?meta.protocol,
-        remote = ?meta.remote_endpoint,
-        local = ?meta.local_endpoint,
-        app_bundle_id = ?meta.source_app_bundle_identifier,
-        app_sign_id = ?meta.source_app_signing_identifier,
-        "flow action: tcp traffic: intercept all"
-    );
-    TransparentProxyFlowAction::Intercept
-}
-
-fn flow_action_udp(
-    meta: &TransparentProxyFlowMeta,
-    remote_host: HostWithPort,
-) -> TransparentProxyFlowAction {
-    if remote_host.port != 443 {
-        tracing::debug!(
-            protocol = ?meta.protocol,
-            remote = ?meta.remote_endpoint,
-            local = ?meta.local_endpoint,
-            app_bundle_id = ?meta.source_app_bundle_identifier,
-            app_sign_id = ?meta.source_app_signing_identifier,
-            "flow action: udp traffic w/ port != 443: pass through"
-        );
-        return TransparentProxyFlowAction::Passthrough;
-    }
-
-    if meta
-        .source_app_bundle_identifier
-        .as_deref()
-        .map(|identifier| {
-            any_starts_with_ignore_ascii_case(
-                identifier,
-                [
-                    // Google Chrome
-                    "com.google.chrome",
-                    // Chromium and forks that reuse upstream id
-                    "org.chromium",
-                    // Microsoft Edge
-                    "com.microsoft.edgemac",
-                    "com.microsoft.msedge",
-                    // Brave
-                    "com.brave.browser",
-                    "com.brave.ios",
-                    // Opera
-                    "com.operasoftware.opera",
-                    // Vivaldi
-                    "com.vivaldi",
-                    // Arc
-                    "company.thebrowser",
-                    // Yandex
-                    "ru.yandex",
-                    // Common alt Chromium builds
-                    "com.github.eloston", // ungoogled chromium
-                ],
-            )
-        })
-        .unwrap_or_default()
-    {
-        tracing::debug!(
-            protocol = ?meta.protocol,
-            remote = ?meta.remote_endpoint,
-            local = ?meta.local_endpoint,
-            app_bundle_id = ?meta.source_app_bundle_identifier,
-            app_sign_id = ?meta.source_app_signing_identifier,
-            "flow action: udp traffic @ port 443: chromium browser detected via source app bundle id: block"
-        );
-        return TransparentProxyFlowAction::Blocked;
-    }
-
-    // NOTE: if we bundle id turns out to not be reliable,
-    // we can also start to check the source app's FS path (location),
-    // based on the audit token... this has however a bundle syscall cost...
-    // so hopefully we can avoid it
-
-    tracing::debug!(
-        protocol = ?meta.protocol,
-        remote = ?meta.remote_endpoint,
-        local = ?meta.local_endpoint,
-        app_bundle_id = ?meta.source_app_bundle_identifier,
-        app_sign_id = ?meta.source_app_signing_identifier,
-        "flow action: udp traffic @ port 443: pass through, chrome not detected"
-    );
-    TransparentProxyFlowAction::Passthrough
-}
-
-fn is_ip_remote_host_passthrough(meta: &TransparentProxyFlowMeta) -> Option<HostWithPort> {
-    let Some(target) = meta.remote_endpoint.as_ref() else {
-        tracing::debug!(
-            protocol = ?meta.protocol,
-            remote = ?meta.remote_endpoint,
-            local = ?meta.local_endpoint,
-            app_bundle_id = ?meta.source_app_bundle_identifier,
-            app_sign_id = ?meta.source_app_signing_identifier,
-            "remote host is missing: passthrough traffic"
-        );
-        return None;
-    };
-
-    match &target.host {
-        Host::Name(_) => return None,
-        Host::Address(addr) => {
-            if is_passthrough_ip(*addr) {
-                tracing::debug!(
-                    protocol = ?meta.protocol,
-                    remote = ?meta.remote_endpoint,
-                    local = ?meta.local_endpoint,
-                    app_bundle_id = ?meta.source_app_bundle_identifier,
-                    app_sign_id = ?meta.source_app_signing_identifier,
-                    "remote host is within passthrough IP range: passthrough traffic"
-                );
-                return None;
-            }
-        }
-    }
-
-    Some(target.clone())
-}
-
-apple_ne::transparent_proxy_ffi! {
-    init = init,
-    config = proxy_config,
-    flow_action = flow_action,
-    tcp_service = self::tcp::try_new_service,
+transparent_proxy_ffi! {
+    init = self::init::init,
+    engine_builder = TransparentProxyEngineBuilder::new(
+        self::handler::FlowHandlerFactory
+    ),
 }

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -3,8 +3,8 @@ use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
 use rama::{
     Layer, Service,
     combinators::Either,
-    error::{BoxError, ErrorContext as _},
-    extensions::ExtensionsMut,
+    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     http::{
         Request, Response, Uri,
@@ -25,15 +25,20 @@ use rama::{
     layer::{ArcLayer, ConsumeErrLayer, HijackLayer},
     net::{
         apple::networkextension::{TcpFlow, tproxy::TransparentProxyServiceContext},
+        client::{ConnectorService, EstablishedClientConnection},
         http::server::HttpPeekRouter,
-        proxy::IoForwardService,
+        proxy::{IoForwardService, ProxyTarget},
         tls::server::PeekTlsClientHelloService,
     },
     proxy::socks5::{proxy::mitm::Socks5MitmRelayService, server::Socks5PeekRouter},
     rt::Executor,
-    tcp::proxy::IoToProxyBridgeIoLayer,
     telemetry::tracing,
-    tls::boring::proxy::{TlsMitmRelay, cert_issuer::BoringMitmCertIssuer},
+    tls::boring::proxy::{
+        TlsMitmRelay,
+        cert_issuer::{
+            BoringMitmCertIssuer, CachedBoringMitmCertIssuer, InMemoryBoringMitmCertIssuer,
+        },
+    },
 };
 
 use safechain_proxy_lib::{
@@ -51,63 +56,89 @@ use safechain_proxy_lib::{
 
 use crate::config::ProxyConfig;
 
-pub(super) async fn try_new_service(
-    ctx: TransparentProxyServiceContext,
-) -> Result<impl Service<TcpFlow, Output = (), Error = Infallible>, BoxError> {
-    let config = ProxyConfig::from_opaque_config(ctx.opaque_config())
-        .context("decode proxy config (json)")?;
+type TcpTlsMitmRelay = TlsMitmRelay<CachedBoringMitmCertIssuer<InMemoryBoringMitmCertIssuer>>;
 
-    let executor = ctx.executor.clone();
-    let data_path = crate::utils::storage::storage_dir().context("(app) data path is missing")?;
-    let root_ca = RootCaKeyPair::try_form_pem(&config.ca_cert_pem, &config.ca_key_pem)
-        .context("load config-provided ca crt/key pair")?;
+#[derive(Clone)]
+pub(super) struct TcpMitmService {
+    proxy_config: ProxyConfig,
+    tls_mitm_relay_policy: TlsMitmRelayPolicyLayer,
+    tls_mitm_relay: TcpTlsMitmRelay,
+    firewall: Firewall,
+    ca_crt_pem_bytes: &'static [u8],
+}
 
-    let ca_crt_pem_bytes: &[u8] = root_ca
-        .certificate()
-        .to_pem()
-        .context("convert cert to pem")?
-        .leak();
+impl TcpMitmService {
+    pub(super) async fn try_new(ctx: TransparentProxyServiceContext) -> Result<Self, BoxError> {
+        let proxy_config = ProxyConfig::from_opaque_config(ctx.opaque_config())
+            .context("decode proxy config (json)")?;
 
-    let (ca_crt, ca_key) = root_ca.into_pair();
+        let data_path =
+            crate::utils::storage::storage_dir().context("(app) data path is missing")?;
+        let root_ca =
+            RootCaKeyPair::try_form_pem(&proxy_config.ca_cert_pem, &proxy_config.ca_key_pem)
+                .context("load config-provided ca crt/key pair")?;
 
-    let guard = ctx
-        .executor
-        .guard()
-        .cloned()
-        .context("L4 engine runtime is expected to inject shutdown guard")?;
+        let ca_crt_pem_bytes: &[u8] = root_ca
+            .certificate()
+            .to_pem()
+            .context("convert cert to pem")?
+            .leak();
 
-    tracing::debug!("creating firewall state for transparent proxy extension");
-    let firewall = create_firewall(
-        guard,
-        Some(data_path),
-        config.agent_identity.clone(),
-        config.reporting_endpoint.clone(),
-        config.aikido_url.clone(),
-    )
-    .await?;
+        let (ca_crt, ca_key) = root_ca.into_pair();
 
-    tracing::debug!("creating middleware and other services");
+        let guard = ctx
+            .executor
+            .guard()
+            .cloned()
+            .context("L4 engine runtime is expected to inject shutdown guard")?;
 
-    let tls_mitm_relay_policy = TlsMitmRelayPolicyLayer::new(firewall.clone());
-    let tls_mitm_relay = TlsMitmRelay::new_cached_in_memory(ca_crt, ca_key);
+        tracing::debug!("creating firewall state for transparent proxy extension");
+        let firewall = create_firewall(
+            guard,
+            Some(data_path),
+            proxy_config.agent_identity.clone(),
+            proxy_config.reporting_endpoint.clone(),
+            proxy_config.aikido_url.clone(),
+        )
+        .await?;
 
-    let mitm_svc = new_tcp_service_inner(
-        executor.clone(),
-        config,
-        tls_mitm_relay_policy,
-        tls_mitm_relay,
-        firewall,
-        ca_crt_pem_bytes,
-        false,
-    );
+        tracing::debug!("creating tcp mitm state for transparent proxy extension");
 
-    Ok((
-        ConsumeErrLayer::trace_as_debug(),
-        IoToProxyBridgeIoLayer::extension_proxy_target_with_connector(
-            new_tcp_connector_service_for_proxy(executor),
-        ),
-    )
-        .into_layer(mitm_svc))
+        Ok(Self {
+            proxy_config,
+            tls_mitm_relay_policy: TlsMitmRelayPolicyLayer::new(firewall.clone()),
+            tls_mitm_relay: TlsMitmRelay::new_cached_in_memory(ca_crt, ca_key),
+            firewall,
+            ca_crt_pem_bytes,
+        })
+    }
+
+    pub(super) fn new_intercept_service(&self, exec: Executor) -> TcpInterceptService {
+        TcpInterceptService {
+            mitm: self.clone(),
+            exec,
+        }
+    }
+
+    fn new_bridge_service<Ingress, Egress>(
+        &self,
+        exec: Executor,
+        within_connect_tunnel: bool,
+    ) -> impl Service<BridgeIo<Ingress, Egress>, Output = (), Error = Infallible> + Clone
+    where
+        Ingress: Io + Unpin + ExtensionsRef,
+        Egress: Io + Unpin + ExtensionsRef,
+    {
+        new_tcp_service_inner(
+            exec,
+            self.proxy_config.clone(),
+            self.tls_mitm_relay_policy.clone(),
+            self.tls_mitm_relay.clone(),
+            self.firewall.clone(),
+            self.ca_crt_pem_bytes,
+            within_connect_tunnel,
+        )
+    }
 }
 
 fn new_tcp_service_inner<Issuer, Ingress, Egress>(
@@ -121,8 +152,8 @@ fn new_tcp_service_inner<Issuer, Ingress, Egress>(
 ) -> impl Service<BridgeIo<Ingress, Egress>, Output = (), Error = Infallible> + Clone
 where
     Issuer: BoringMitmCertIssuer<Error: Into<BoxError>> + Clone,
-    Ingress: Io + Unpin + ExtensionsMut,
-    Egress: Io + Unpin + ExtensionsMut,
+    Ingress: Io + Unpin + ExtensionsRef,
+    Egress: Io + Unpin + ExtensionsRef,
 {
     let peek_duration = Duration::from_secs_f64(proxy_config.peek_duration_s.max(0.05));
 
@@ -262,5 +293,46 @@ async fn create_firewall(
                 "shutdown initiated prior to firewall created; exit process immediately",
             ))
         }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct TcpInterceptService {
+    mitm: TcpMitmService,
+    exec: Executor,
+}
+
+impl Service<TcpFlow> for TcpInterceptService {
+    type Output = ();
+    type Error = Infallible;
+
+    async fn serve(&self, ingress: TcpFlow) -> Result<Self::Output, Self::Error> {
+        let Some(ProxyTarget(egress_addr)) = ingress.extensions().get_ref().cloned() else {
+            tracing::debug!("missing ProxyTarget in transparent proxy tcp service");
+            return Ok(());
+        };
+
+        let connector = new_tcp_connector_service_for_proxy(self.exec.clone());
+        let tcp_req = rama::tcp::client::Request::new_with_extensions(
+            egress_addr.clone(),
+            ingress.extensions().clone(),
+        );
+
+        let EstablishedClientConnection { conn: egress, .. } =
+            match connector.connect(tcp_req).await {
+                Ok(connection) => connection,
+                Err(err) => {
+                    tracing::debug!(
+                        address = %egress_addr,
+                        error = %err.into_box_error(),
+                        "transparent proxy tcp connect failed"
+                    );
+                    return Ok(());
+                }
+            };
+
+        let mitm_svc = self.mitm.new_bridge_service(self.exec.clone(), false);
+        let _ = mitm_svc.serve(BridgeIo(ingress, egress)).await;
+        Ok(())
     }
 }

--- a/proxy-lib/src/http/firewall/layer.rs
+++ b/proxy-lib/src/http/firewall/layer.rs
@@ -1,7 +1,7 @@
 use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext},
-    extensions::{ExtensionsMut, ExtensionsRef},
+    extensions::ExtensionsRef,
     http::{Request, Response},
 };
 
@@ -48,7 +48,7 @@ where
     async fn serve(&self, req: Request) -> Result<Self::Output, Self::Error> {
         // If the request already had a TLS handshake we just take the rules that have been matched
         // if not the case (e.g. insecure http traffic), we match here with match_http_rules (same function being used during tls handshake)
-        let maybe_http_rules = match req.extensions().get().cloned() {
+        let maybe_http_rules = match req.extensions().get_ref().cloned() {
             Some(rules) => Some(rules),
             None => try_get_domain_for_req(&req).and_then(|domain| {
                 self.firewall.match_http_rules(&super::IncomingFlowInfo {
@@ -61,8 +61,8 @@ where
 
         if let Some(http_rules) = maybe_http_rules {
             let mod_req = match http_rules.evaluate_http_request(req).await? {
-                RequestAction::Allow(mut allowed_mod_req) => {
-                    allowed_mod_req.extensions_mut().insert(http_rules.clone());
+                RequestAction::Allow(allowed_mod_req) => {
+                    allowed_mod_req.extensions().insert(http_rules.clone());
                     allowed_mod_req
                 }
                 RequestAction::Block(blocked) => {

--- a/proxy-lib/src/http/firewall/matched_rules.rs
+++ b/proxy-lib/src/http/firewall/matched_rules.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rama::{
     Service,
     error::BoxError,
-    extensions::ExtensionsRef,
+    extensions::{Extension, ExtensionsRef},
     http::{
         Request, Response,
         ws::handshake::mitm::{WebSocketRelayDirection, WebSocketRelayInput, WebSocketRelayOutput},
@@ -13,7 +13,7 @@ use rama::{
 
 use super::rule::{HttpRequestMatcherView, HttpResponseMatcherView, RequestAction, Rule as _};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Extension)]
 /// Matched firewall rules for http traffic and protocols built upon it.
 ///
 /// Can be created via the Firewall by matching on the target domain.
@@ -124,7 +124,7 @@ where
     ) -> Result<ServiceMatch<Self::ModifiedInput, Self::Service>, Self::Error> {
         let service = req
             .extensions()
-            .get()
+            .get_ref()
             .and_then(|rules: &FirewallHttpRules| {
                 rules.select_http_response_payload_inspection_rules(&req)
             });

--- a/proxy-lib/src/http/req_info.rs
+++ b/proxy-lib/src/http/req_info.rs
@@ -7,7 +7,7 @@ use rama::{
 };
 
 pub fn try_get_domain_for_req<Body>(req: &Request<Body>) -> Option<Cow<'_, Domain>> {
-    if let Some(ProxyTarget(target)) = req.extensions().get()
+    if let Some(ProxyTarget(target)) = req.extensions().get_ref()
         && let Some(domain) = target.host.as_domain()
     {
         Some(Cow::Borrowed(domain))

--- a/proxy-lib/src/http/ws_relay.rs
+++ b/proxy-lib/src/http/ws_relay.rs
@@ -39,8 +39,8 @@ impl WebSocketMitmRelayService {
 
 impl<Ingress, Egress> Service<BridgeIo<Ingress, Egress>> for WebSocketMitmRelayService
 where
-    Ingress: Io + Unpin + extensions::ExtensionsMut,
-    Egress: Io + Unpin + extensions::ExtensionsMut,
+    Ingress: Io + Unpin + extensions::ExtensionsRef,
+    Egress: Io + Unpin + extensions::ExtensionsRef,
 {
     type Output = ();
     type Error = BoxError;
@@ -49,13 +49,13 @@ where
         &self,
         bridge_io: BridgeIo<Ingress, Egress>,
     ) -> Result<Self::Output, Self::Error> {
-        let proxy_target = bridge_io.extensions().get::<ProxyTarget>().cloned();
+        let proxy_target = bridge_io.extensions().get_arc::<ProxyTarget>();
         let source_app_bundle_id =
             get_app_source_bundle_id_from_ext(&bridge_io).map(|s| s.to_smolstr());
         let source_process_path =
             get_source_process_path_from_ext(&bridge_io).map(|s| s.to_smolstr());
 
-        if let Some(http_rules) = bridge_io.extensions().get::<FirewallHttpRules>()
+        if let Some(http_rules) = bridge_io.extensions().get_ref::<FirewallHttpRules>()
             && let Some(ws_rules) = http_rules.match_ws_rules(WebSocketHandshakeInfo {
                 domain: proxy_target
                     .as_ref()
@@ -64,7 +64,7 @@ where
                 source_process_path: get_source_process_path_from_ext(&bridge_io).as_deref(),
                 req_headers: bridge_io
                     .extensions()
-                    .get::<HttpWebSocketRelayHandshakeRequest>()
+                    .get_ref::<HttpWebSocketRelayHandshakeRequest>()
                     .map(|req| req.0.as_ref()),
             })
         {

--- a/proxy-lib/src/tcp/connector.rs
+++ b/proxy-lib/src/tcp/connector.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use rama::{
     error::BoxError,
-    extensions::ExtensionsMut,
+    extensions::ExtensionsRef,
     io::Io,
     net::{
         client::ConnectorService,
@@ -25,7 +25,7 @@ pub fn new_tcp_connector_service_for_internal<Input>(
 ) -> impl ConnectorService<Input, Connection: Io + Unpin> + Clone
 where
     Input:
-        ExtensionsMut + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
+        ExtensionsRef + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
     BoxError: From<Input::Error>,
 {
     TcpConnector::new(exec)
@@ -38,7 +38,7 @@ pub fn new_tcp_connector_service_for_proxy<Input>(
 ) -> impl ConnectorService<Input, Connection: Io + Unpin> + Clone
 where
     Input:
-        ExtensionsMut + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
+        ExtensionsRef + TryRefIntoTransportContext<Error: Send + Sync + 'static> + Send + 'static,
     BoxError: From<Input::Error>,
 {
     TcpConnector::new(exec).with_connector(Arc::new(SocketOptions {

--- a/proxy-lib/src/tls/mitm_relay_policy.rs
+++ b/proxy-lib/src/tls/mitm_relay_policy.rs
@@ -4,7 +4,7 @@ use moka::{Equivalent, policy::EvictionPolicy};
 use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext as _, ErrorExt as _},
-    extensions::{self, ExtensionsMut},
+    extensions::ExtensionsRef,
     io::{BridgeIo, Io},
     net::{
         address::Domain,
@@ -130,8 +130,8 @@ impl<Issuer, Inner, Ingress, Egress> Service<InputWithClientHello<BridgeIo<Ingre
 where
     Issuer: BoringMitmCertIssuer<Error: Into<BoxError>>,
     Inner: Service<BridgeIo<TlsStream<Ingress>, TlsStream<Egress>>, Output = (), Error: Into<BoxError>>,
-    Ingress: Io + Unpin + extensions::ExtensionsMut,
-    Egress: Io + Unpin + extensions::ExtensionsMut,
+    Ingress: Io + Unpin + ExtensionsRef,
+    Egress: Io + Unpin + ExtensionsRef,
 {
     type Output = ();
     type Error = BoxError;
@@ -139,7 +139,7 @@ where
     async fn serve(
         &self,
         InputWithClientHello {
-            input: mut bridge_io,
+            input: bridge_io,
             client_hello,
         }: InputWithClientHello<BridgeIo<Ingress, Egress>>,
     ) -> Result<Self::Output, Self::Error> {
@@ -171,7 +171,7 @@ where
             match self.firewall.match_http_rules(&incoming_flow_info) {
                 Some(http_rules) => {
                     // insert the http rules so that they can be used after tls handshake for ws & for our fw layer
-                    bridge_io.extensions_mut().insert(http_rules);
+                    bridge_io.extensions().insert(http_rules);
                 }
                 None if self.mitm_all => (),
                 None => {

--- a/proxy-lib/src/utils/net.rs
+++ b/proxy-lib/src/utils/net.rs
@@ -1,4 +1,5 @@
-use rama::extensions::ExtensionsRef;
+use rama::extensions::{Extension, ExtensionsRef};
+use std::sync::Arc;
 
 #[cfg(not(all(feature = "apple-networkextension", target_os = "macos")))]
 pub fn get_app_source_bundle_id_from_ext(_: &impl ExtensionsRef) -> Option<&str> {
@@ -21,12 +22,17 @@ pub fn get_source_process_path_from_ext(_: &impl ExtensionsRef) -> Option<String
     None
 }
 
+#[derive(Debug, Clone, Extension)]
+pub struct ProxyRedirectContextExt(
+    pub Arc<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>,
+);
+
 #[cfg(all(target_os = "windows", feature = "windows-driver"))]
 pub fn get_source_process_path_from_ext(input: &impl ExtensionsRef) -> Option<String> {
     input
         .extensions()
-        .get_ref::<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>()
-        .and_then(|ctx| ctx.source_process_path())
+        .get_ref()
+        .and_then(|ProxyRedirectContextExt(ctx)| ctx.source_process_path())
         .map(|s| s.to_owned())
 }
 

--- a/proxy-lib/src/utils/net.rs
+++ b/proxy-lib/src/utils/net.rs
@@ -1,5 +1,4 @@
-use rama::extensions::{Extension, ExtensionsRef};
-use std::sync::Arc;
+use rama::extensions::ExtensionsRef;
 
 #[cfg(not(all(feature = "apple-networkextension", target_os = "macos")))]
 pub fn get_app_source_bundle_id_from_ext(_: &impl ExtensionsRef) -> Option<&str> {
@@ -22,9 +21,10 @@ pub fn get_source_process_path_from_ext(_: &impl ExtensionsRef) -> Option<String
     None
 }
 
-#[derive(Debug, Clone, Extension)]
+#[cfg(all(target_os = "windows", feature = "windows-driver"))]
+#[derive(Debug, Clone, rama::extensions::Extension)]
 pub struct ProxyRedirectContextExt(
-    pub Arc<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>,
+    pub std::sync::Arc<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>,
 );
 
 #[cfg(all(target_os = "windows", feature = "windows-driver"))]

--- a/proxy-lib/src/utils/net.rs
+++ b/proxy-lib/src/utils/net.rs
@@ -25,7 +25,7 @@ pub fn get_source_process_path_from_ext(_: &impl ExtensionsRef) -> Option<String
 pub fn get_source_process_path_from_ext(input: &impl ExtensionsRef) -> Option<String> {
     input
         .extensions()
-        .get::<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>()
+        .get_ref::<safechain_proxy_lib_nostd::windows::redirect_ctx::ProxyRedirectContext>()
         .and_then(|ctx| ctx.source_process_path())
         .map(|s| s.to_owned())
 }

--- a/proxy-lib/src/utils/net.rs
+++ b/proxy-lib/src/utils/net.rs
@@ -7,11 +7,9 @@ pub fn get_app_source_bundle_id_from_ext(_: &impl ExtensionsRef) -> Option<&str>
 
 #[cfg(all(feature = "apple-networkextension", target_os = "macos"))]
 pub fn get_app_source_bundle_id_from_ext(input: &impl ExtensionsRef) -> Option<&str> {
-    use std::sync::Arc;
-
     input
         .extensions()
-        .get::<Arc<rama::net::apple::networkextension::tproxy::TransparentProxyFlowMeta>>()
+        .get_ref::<rama::net::apple::networkextension::tproxy::TransparentProxyFlowMeta>()
         .and_then(|meta| meta.source_app_bundle_identifier.as_deref())
 }
 
@@ -34,11 +32,9 @@ pub fn get_source_process_path_from_ext(input: &impl ExtensionsRef) -> Option<St
 
 #[cfg(all(target_os = "macos", feature = "apple-networkextension"))]
 pub fn get_source_process_path_from_ext(input: &impl ExtensionsRef) -> Option<String> {
-    use std::sync::Arc;
-
     let meta = input
         .extensions()
-        .get::<Arc<rama::net::apple::networkextension::tproxy::TransparentProxyFlowMeta>>()?;
+        .get_ref::<rama::net::apple::networkextension::tproxy::TransparentProxyFlowMeta>()?;
 
     let pid = meta.source_app_pid?;
 


### PR DESCRIPTION
this also comes with a lot of fixes and improvements regarding:

- extension management (migrated to append vec internally, making it &self-compatible)
- lifecycle management and fixes for transport-layer connects and apple NE
- many other small improvements, combined improving all of safechain-internals proxies, not just the apple l4 macos one

It can now also handle a full-range port scan, e.g.:

```bash
>  $HOME/go/bin/naabu -host hackerone.com -p -

[INF] Found 65535 ports on host hackerone.com (2606:4700:440a::6812:24d6)
[INF] Found 65535 ports on host hackerone.com (104.18.36.214)
```

As you can see however, it does mean such port scanning results are bogus,
given the L4 flow will accept them all...

The port scanning case has served as a good stress test and has helped to improve a lot of different
parts of rama. That said... while the safechain internal proxies can now handle that load on endpoint devices,
it is not recommended to run such tooling on these devices as anyway the results are incorrect...

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Adapted macOS L4 proxy to new rama transparent proxy engine API
* Improved Windows WFP context handling and preserved redirect context in Arc
* Bumped Rama dependency revision in macOS packaging project files

**🔧 Refactors**
* Replaced mutable extensions APIs with reference-based ExtensionsRef across modules
* Refactored TCP MITM service into TcpMitmService struct and builder functions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106897188?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->