### PR TITLE
Fix (ui): require daemon CLI flags; block manual relaunch without args

### DIFF
--- a/ui/Taskfile.yml
+++ b/ui/Taskfile.yml
@@ -9,6 +9,13 @@ vars:
   APP_NAME: "endpoint-protection-ui"
   BIN_DIR: "bin"
   VITE_PORT: '{{.WAILS_VITE_PORT | default 9245}}'
+  # Default CLI flags forwarded to the app binary in dev mode. These match the
+  # built-in defaults in daemon/client.go and appserver/server.go so `task dev`
+  # works without extra configuration.
+  DEV_DAEMON_URL: '{{.DEV_DAEMON_URL | default "http://127.0.0.1:7878"}}'
+  DEV_TOKEN: '{{.DEV_TOKEN | default "devtoken"}}'
+  DEV_UI_URL: '{{.DEV_UI_URL | default "127.0.0.1:9876"}}'
+  APP_ARGS: '-daemon_url {{.DEV_DAEMON_URL}} -token {{.DEV_TOKEN}} -ui_url {{.DEV_UI_URL}}'
 
 tasks:
   build:
@@ -25,6 +32,8 @@ tasks:
     summary: Runs the application
     cmds:
       - task: "{{OS}}:run"
+        vars:
+          APP_ARGS: '{{.APP_ARGS}}'
 
   dev:
     summary: Runs the application in development mode

--- a/ui/build/darwin/Taskfile.yml
+++ b/ui/build/darwin/Taskfile.yml
@@ -132,7 +132,7 @@ tasks:
       - cp "{{.BIN_DIR}}/{{.APP_NAME}}" "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS"
       - cp "build/darwin/Info.dev.plist" "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/Info.plist"
       - codesign --force --deep --sign - "{{.BIN_DIR}}/{{.APP_NAME}}.dev.app"
-      - '{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS/{{.APP_NAME}}'
+      - '{{.BIN_DIR}}/{{.APP_NAME}}.dev.app/Contents/MacOS/{{.APP_NAME}} {{.APP_ARGS}}'
 
   # sign:
   #   summary: Signs the application bundle with Developer ID

--- a/ui/build/windows/Taskfile.yml
+++ b/ui/build/windows/Taskfile.yml
@@ -111,7 +111,7 @@ tasks:
 
   run:
     cmds:
-      - '{{.BIN_DIR}}/{{.APP_NAME}}.exe'
+      - '{{.BIN_DIR}}/{{.APP_NAME}}.exe {{.APP_ARGS}}'
 
   sign:
     summary: Signs the Windows executable

--- a/ui/main.go
+++ b/ui/main.go
@@ -52,11 +52,25 @@ type appFlags struct {
 
 func parseFlags() appFlags {
 	f := appFlags{}
-	flag.StringVar(&f.daemonURL, "daemon_url", "", "Daemon API base URL (default http://127.0.0.1:7878)")
-	flag.StringVar(&f.token, "token", "", "Daemon API auth token (default devtoken)")
-	flag.StringVar(&f.uiURL, "ui_url", "", "Address the UI app server listens on (default 127.0.0.1:9876)")
+	flag.StringVar(&f.daemonURL, "daemon_url", "", "Daemon API base URL (required)")
+	flag.StringVar(&f.token, "token", "", "Daemon API auth token (required)")
+	flag.StringVar(&f.uiURL, "ui_url", "", "Address the UI app server listens on (required)")
 	flag.StringVar(&f.logFile, "log_file", "", "Path to the log file")
 	flag.Parse()
+
+	var missing []string
+	if f.daemonURL == "" {
+		missing = append(missing, "-daemon_url")
+	}
+	if f.token == "" {
+		missing = append(missing, "-token")
+	}
+	if f.uiURL == "" {
+		missing = append(missing, "-ui_url")
+	}
+	if len(missing) > 0 {
+		log.Fatalf("missing required flag(s): %s", strings.Join(missing, ", "))
+	}
 	return f
 }
 
@@ -65,12 +79,8 @@ func applyFlags(f appFlags) {
 		setupLogging(f.logFile)
 		log.Println("Logging to file:", f.logFile)
 	}
-	if f.daemonURL != "" || f.token != "" {
-		daemon.SetConfig(f.daemonURL, f.token)
-	}
-	if f.uiURL != "" {
-		appserver.SetListenAddr(f.uiURL)
-	}
+	daemon.SetConfig(f.daemonURL, f.token)
+	appserver.SetListenAddr(f.uiURL)
 }
 
 // --- Notifications -------------------------------------------------------


### PR DESCRIPTION
Quit (e.g. `Cmd+Q`) then opening the app from Finder passed no flags and used to start on defaults. Required -daemon_url, -token, -ui_url fixes that. Daemon still relaunches the tray via heartbeat within ~15s.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Wired development CLI defaults into Taskfile and forwarded to run

**⚡ Enhancements**
* Required daemon CLI flags and aborted startup when missing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106631428?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->