### PR TITLE
refactor: Introduce a new make_response_uncacheable to be re-used

### DIFF
--- a/proxy-lib/src/http/firewall/rule/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/mod.rs
@@ -5,7 +5,11 @@ use rama::{
     extensions::{Extensions, ExtensionsRef as _},
     http::{
         Method, Request, Response, StatusCode, Uri, Version,
-        header::{HeaderMap, HeaderValue},
+        header::{self, HeaderMap, HeaderValue},
+        headers::{CacheControl, HeaderMapExt as _},
+        layer::remove_header::{
+            remove_cache_policy_headers, remove_cache_validation_response_headers,
+        },
         request,
         ws::handshake::mitm::{WebSocketRelayDirection, WebSocketRelayOutput},
     },
@@ -44,6 +48,17 @@ pub(crate) fn block_reason_for(decision: PackagePolicyDecision) -> BlockReason {
             unreachable!("Allow and Defer are not blocking decisions")
         }
     }
+}
+
+/// Strips all caching headers and inserts `Cache-Control: no-cache`.
+///
+/// Used by min-package-age rules after rewriting a response body so that
+/// the client cannot serve a stale, unfiltered copy from its own cache.
+pub(in crate::http::firewall) fn make_response_uncacheable(headers: &mut HeaderMap) {
+    remove_cache_policy_headers(headers);
+    remove_cache_validation_response_headers(headers);
+    headers.remove(header::CONTENT_LENGTH);
+    headers.typed_insert(CacheControl::new().with_no_cache());
 }
 
 #[cfg(feature = "pac")]

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
@@ -5,10 +5,7 @@ use rama::{
     http::{
         Body, Request, Response,
         body::util::BodyExt as _,
-        headers::{Accept, CacheControl, ContentType, HeaderMapExt as _},
-        layer::remove_header::{
-            remove_cache_policy_headers, remove_cache_validation_response_headers,
-        },
+        headers::{Accept, ContentType, HeaderMapExt as _},
     },
     telemetry::tracing,
     utils::{str::arcstr::ArcStr, time::now_unix_ms},
@@ -103,11 +100,7 @@ impl MinPackageAge {
         let new_bytes =
             serde_json::to_vec(&json).context("serialize modified npm info response")?;
 
-        remove_cache_policy_headers(&mut parts.headers);
-        remove_cache_validation_response_headers(&mut parts.headers);
-        parts
-            .headers
-            .typed_insert(CacheControl::new().with_no_cache());
+        super::super::make_response_uncacheable(&mut parts.headers);
 
         if let Some(notifier) = &self.notifier {
             let event = MinPackageAgeEvent {

--- a/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
@@ -3,11 +3,7 @@ use rama::{
     http::{
         Body, Response,
         body::util::BodyExt as _,
-        header,
-        headers::{CacheControl, ContentType, HeaderMapExt as _},
-        layer::remove_header::{
-            remove_cache_policy_headers, remove_cache_validation_response_headers,
-        },
+        headers::{ContentType, HeaderMapExt as _},
     },
     telemetry::tracing,
     utils::{str::arcstr::ArcStr, time::now_unix_ms},
@@ -81,7 +77,7 @@ impl MinPackageAgePyPI {
                     "PyPI metadata rewritten: suppressed too-young versions"
                 );
 
-                Self::make_uncacheable(&mut parts.headers);
+                super::super::make_response_uncacheable(&mut parts.headers);
                 self.notify_rewrite(&rewrite).await;
 
                 Ok(Response::from_parts(parts, Body::from(rewrite.bytes)))
@@ -93,7 +89,7 @@ impl MinPackageAgePyPI {
                 // HTML is streamed through lol_html without buffering the full body.
                 // Cache headers are stripped upfront because we cannot defer
                 // header writes until the body is fully consumed.
-                Self::make_uncacheable(&mut parts.headers);
+                super::super::make_response_uncacheable(&mut parts.headers);
 
                 let notifier = self.notifier.clone();
                 let streaming_body = html::rewrite_body(
@@ -106,13 +102,6 @@ impl MinPackageAgePyPI {
                 Ok(Response::from_parts(parts, Body::new(streaming_body)))
             }
         }
-    }
-
-    fn make_uncacheable(headers: &mut rama::http::HeaderMap) {
-        remove_cache_policy_headers(headers);
-        remove_cache_validation_response_headers(headers);
-        headers.remove(header::CONTENT_LENGTH);
-        headers.typed_insert(CacheControl::new().with_no_cache());
     }
 
     async fn notify_rewrite(&self, rewrite: &JsonRewriteResult) {


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Extracted make_response_uncacheable and used it in min-package-age handlers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106730034?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->