### PR TITLE
Add req_uri to evaluate_response for future firewall rules

### DIFF
--- a/proxy-lib/src/http/firewall/layer.rs
+++ b/proxy-lib/src/http/firewall/layer.rs
@@ -2,7 +2,7 @@ use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext},
     extensions::{ExtensionsMut, ExtensionsRef},
-    http::{Request, Response},
+    http::{Request, Response, Uri},
 };
 
 use crate::{
@@ -73,8 +73,9 @@ where
                 }
             };
 
+            let req_uri: Uri = mod_req.uri().clone();
             let resp = self.inner.serve(mod_req).await.into_box_error()?;
-            Ok(http_rules.evaluate_http_response(resp).await?)
+            Ok(http_rules.evaluate_http_response(resp, &req_uri).await?)
         } else {
             self.inner.serve(req).await.into_box_error()
         }

--- a/proxy-lib/src/http/firewall/matched_rules.rs
+++ b/proxy-lib/src/http/firewall/matched_rules.rs
@@ -5,7 +5,7 @@ use rama::{
     error::BoxError,
     extensions::ExtensionsRef,
     http::{
-        Request, Response,
+        Request, Response, Uri,
         ws::handshake::mitm::{WebSocketRelayDirection, WebSocketRelayInput, WebSocketRelayOutput},
     },
     matcher::service::{ServiceMatch, ServiceMatcher},
@@ -65,12 +65,13 @@ impl FirewallHttpRules {
     pub(super) async fn evaluate_http_response(
         &self,
         resp: Response,
+        req_uri: &Uri,
     ) -> Result<Response, BoxError> {
         let mut mod_resp = resp;
 
         // Iterate rules in reverse order for symmetry with request evaluation
         for rule in self.0.iter().rev() {
-            mod_resp = rule.evaluate_response(mod_resp).await?;
+            mod_resp = rule.evaluate_response(mod_resp, req_uri).await?;
         }
 
         Ok(mod_resp)

--- a/proxy-lib/src/http/firewall/rule/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/mod.rs
@@ -296,10 +296,12 @@ pub trait Rule: Sized + Send + Sync + 'static {
     ///                                      |
     ///                                      └──> Can Modify or Replace
     /// ```
-    fn evaluate_response(
-        &self,
+    fn evaluate_response<'r>(
+        &'r self,
         resp: Response,
-    ) -> impl Future<Output = Result<Response, BoxError>> + Send + '_ {
+        req_uri: &'r Uri,
+    ) -> impl Future<Output = Result<Response, BoxError>> + Send + 'r {
+        let _ = req_uri;
         std::future::ready(Ok(resp))
     }
 
@@ -341,10 +343,11 @@ trait DynRuleInner {
         req: Request,
     ) -> Pin<Box<dyn Future<Output = Result<RequestAction, BoxError>> + Send + '_>>;
 
-    fn dyn_evaluate_response(
-        &self,
+    fn dyn_evaluate_response<'r>(
+        &'r self,
         resp: Response,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + '_>>;
+        req_uri: &'r Uri,
+    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'r>>;
 
     fn dyn_match_domain(&self, domain: &Domain) -> bool;
 
@@ -383,11 +386,12 @@ impl<R: Rule> DynRuleInner for R {
 
     #[inline(always)]
     /// see [`Rule::evaluate_response`] for more information.
-    fn dyn_evaluate_response(
-        &self,
+    fn dyn_evaluate_response<'r>(
+        &'r self,
         resp: Response,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + '_>> {
-        Box::pin(self.evaluate_response(resp))
+        req_uri: &'r Uri,
+    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'r>> {
+        Box::pin(self.evaluate_response(resp, req_uri))
     }
 
     #[inline(always)]
@@ -472,11 +476,12 @@ impl Rule for DynRule {
     }
 
     #[inline(always)]
-    fn evaluate_response(
-        &self,
+    fn evaluate_response<'r>(
+        &'r self,
         resp: Response,
-    ) -> impl Future<Output = Result<Response, BoxError>> + Send + '_ {
-        self.inner.dyn_evaluate_response(resp)
+        req_uri: &'r Uri,
+    ) -> impl Future<Output = Result<Response, BoxError>> + Send + 'r {
+        self.inner.dyn_evaluate_response(resp, req_uri)
     }
 
     #[inline(always)]

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -139,7 +139,11 @@ impl Rule for RuleNpm {
     }
 
     #[inline(always)]
-    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
+    async fn evaluate_response(
+        &self,
+        resp: Response,
+        _req_uri: &Uri,
+    ) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => min_package_age.remove_new_packages(resp).await,
             None => Ok(resp),

--- a/proxy-lib/src/http/firewall/rule/nuget/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/nuget/mod.rs
@@ -177,7 +177,11 @@ impl Rule for RuleNuget {
     }
 
     #[inline(always)]
-    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
+    async fn evaluate_response(
+        &self,
+        resp: Response,
+        _req_uri: &Uri,
+    ) -> Result<Response, BoxError> {
         Ok(resp)
     }
 

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -229,7 +229,11 @@ impl Rule for RulePyPI {
     }
 
     #[inline(always)]
-    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
+    async fn evaluate_response(
+        &self,
+        resp: Response,
+        _req_uri: &Uri,
+    ) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
                 min_package_age


### PR DESCRIPTION
necessary for golang

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed Rule::evaluate_response signature to accept request URI parameter for future firewall rules
* Propagated request URI through firewall to rule response evaluators and call sites


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106732712?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->