### PR TITLE
replace BoxError::from(str) w/ OpaqueError::from_static_str

### DIFF
--- a/proxy-bin-l4-windows-driver-object/src/common.rs
+++ b/proxy-bin-l4-windows-driver-object/src/common.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use rama_core::{
-    error::{BoxError, ErrorExt as _},
+    error::{BoxError, ErrorExt as _, extra::OpaqueError},
     telemetry::tracing::{debug, info, warn},
 };
 use windows_sys::Win32::{
@@ -82,13 +82,13 @@ pub fn enable_device(service_name: &str) -> Result<(), BoxError> {
                 );
             }
             _ => {
-                return Err(
-                    BoxError::from("failed to prepare device restart before enable")
-                        .context_str_field("name", service_name)
-                        .context_str_field("instance_id", &device.instance_id)
-                        .context_field("cfgmgr32", restart_disable_cr)
-                        .context_str_field("cfgmgr32_name", configret_name(restart_disable_cr)),
-                );
+                return Err(OpaqueError::from_static_str(
+                    "failed to prepare device restart before enable",
+                )
+                .context_str_field("name", service_name)
+                .context_str_field("instance_id", &device.instance_id)
+                .context_field("cfgmgr32", restart_disable_cr)
+                .context_str_field("cfgmgr32_name", configret_name(restart_disable_cr)));
             }
         }
 
@@ -97,7 +97,7 @@ pub fn enable_device(service_name: &str) -> Result<(), BoxError> {
             CM_Enable_DevNode(device.devinst, 0)
         };
         if cr != CR_SUCCESS {
-            return Err(BoxError::from("failed to enable device")
+            return Err(OpaqueError::from_static_str("failed to enable device")
                 .context_str_field("name", service_name)
                 .context_str_field("instance_id", &device.instance_id)
                 .context_field("cfgmgr32", cr));
@@ -135,13 +135,13 @@ pub fn disable_device(service_name: &str, force_remove_on_veto: bool) -> Result<
             );
             let remove_cr = force_remove_devinst(device.devinst, &device.instance_id);
             if remove_cr != CR_SUCCESS {
-                return Err(
-                    BoxError::from("failed to force-remove device after disable veto")
-                        .context_str_field("name", service_name)
-                        .context_str_field("instance_id", &device.instance_id)
-                        .context_field("cfgmgr32", remove_cr)
-                        .context_str_field("cfgmgr32_name", configret_name(remove_cr)),
-                );
+                return Err(OpaqueError::from_static_str(
+                    "failed to force-remove device after disable veto",
+                )
+                .context_str_field("name", service_name)
+                .context_str_field("instance_id", &device.instance_id)
+                .context_field("cfgmgr32", remove_cr)
+                .context_str_field("cfgmgr32_name", configret_name(remove_cr)));
             }
 
             info!(
@@ -153,7 +153,7 @@ pub fn disable_device(service_name: &str, force_remove_on_veto: bool) -> Result<
         }
 
         if cr != CR_SUCCESS {
-            return Err(BoxError::from("failed to disable device")
+            return Err(OpaqueError::from_static_str("failed to disable device")
                 .context_str_field("name", service_name)
                 .context_str_field("instance_id", &device.instance_id)
                 .context_field("cfgmgr32", cr)
@@ -289,8 +289,10 @@ impl DeviceInfoSet {
             )
         };
         if handle == INVALID_HANDLE_VALUE as isize {
-            return Err(BoxError::from("failed to enumerate device info set")
-                .context_field("win32", unsafe { GetLastError() }));
+            return Err(
+                OpaqueError::from_static_str("failed to enumerate device info set")
+                    .context_field("win32", unsafe { GetLastError() }),
+            );
         }
         Ok(Self(handle))
     }
@@ -333,7 +335,7 @@ fn find_devices_for_service(service_name: &str) -> Result<Vec<MatchedDevice>, Bo
                 break;
             }
 
-            return Err(BoxError::from("failed to enumerate devices")
+            return Err(OpaqueError::from_static_str("failed to enumerate devices")
                 .context_str_field("name", service_name)
                 .context_field("win32", code));
         }
@@ -387,7 +389,7 @@ fn query_device_registry_string_property(
         )
     };
     if ok != 0 {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "unexpected success while probing device registry property size",
         )
         .context_field("property", property));
@@ -398,9 +400,11 @@ fn query_device_registry_string_property(
         return Ok(None);
     }
     if code != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
-        return Err(BoxError::from("failed to query device registry property")
-            .context_field("property", property)
-            .context_field("win32", code));
+        return Err(
+            OpaqueError::from_static_str("failed to query device registry property")
+                .context_field("property", property)
+                .context_field("win32", code),
+        );
     }
 
     let mut buffer = vec![0_u16; (required_size as usize).div_ceil(2)];
@@ -417,15 +421,19 @@ fn query_device_registry_string_property(
         )
     };
     if ok == 0 {
-        return Err(BoxError::from("failed to read device registry property")
-            .context_field("property", property)
-            .context_field("win32", unsafe { GetLastError() }));
+        return Err(
+            OpaqueError::from_static_str("failed to read device registry property")
+                .context_field("property", property)
+                .context_field("win32", unsafe { GetLastError() }),
+        );
     }
 
     if !matches!(property_type, REG_SZ | REG_EXPAND_SZ | REG_MULTI_SZ) {
-        return Err(BoxError::from("device registry property was not a string value")
-            .context_field("property", property)
-            .context_field("property_type", property_type));
+        return Err(OpaqueError::from_static_str(
+            "device registry property was not a string value",
+        )
+        .context_field("property", property)
+        .context_field("property_type", property_type));
     }
 
     Ok(Some(from_wide_with_nul(&buffer)))
@@ -447,15 +455,17 @@ fn query_device_instance_id(
         )
     };
     if ok != 0 {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "unexpected success while probing device instance id size",
-        ));
+        )
+        .into_box_error());
     }
 
     let code = unsafe { GetLastError() };
     if code != ERROR_INSUFFICIENT_BUFFER || required_size == 0 {
         return Err(
-            BoxError::from("failed to query device instance id size").context_field("win32", code)
+            OpaqueError::from_static_str("failed to query device instance id size")
+                .context_field("win32", code),
         );
     }
 
@@ -471,8 +481,10 @@ fn query_device_instance_id(
         )
     };
     if ok == 0 {
-        return Err(BoxError::from("failed to read device instance id")
-            .context_field("win32", unsafe { GetLastError() }));
+        return Err(
+            OpaqueError::from_static_str("failed to read device instance id")
+                .context_field("win32", unsafe { GetLastError() }),
+        );
     }
 
     Ok(from_wide_with_nul(&buffer))
@@ -504,7 +516,7 @@ impl DeviceHandle {
             )
         };
         if handle == INVALID_HANDLE_VALUE {
-            return Err(BoxError::from("failed to open device")
+            return Err(OpaqueError::from_static_str("failed to open device")
                 .context_str_field("device_path", device_path)
                 .context_field("win32", unsafe { GetLastError() }));
         }
@@ -548,7 +560,7 @@ impl DeviceHandle {
         }
 
         Err(last_error.unwrap_or_else(|| {
-            BoxError::from("failed to open device after retry")
+            OpaqueError::from_static_str("failed to open device after retry")
                 .context_str_field("device_path", device_path)
         }))
     }
@@ -578,9 +590,11 @@ impl DeviceHandle {
             )
         };
         if ok == 0 {
-            return Err(BoxError::from("DeviceIoControl failed for ioctl")
-                .context_hex_field("ioctl", ioctl)
-                .context_field("win32", unsafe { GetLastError() }));
+            return Err(
+                OpaqueError::from_static_str("DeviceIoControl failed for ioctl")
+                    .context_hex_field("ioctl", ioctl)
+                    .context_field("win32", unsafe { GetLastError() }),
+            );
         }
 
         debug!(ioctl = format_args!("{ioctl:#x}"), "driver ioctl completed");

--- a/proxy-bin-l4-windows-driver-object/src/wfp.rs
+++ b/proxy-bin-l4-windows-driver-object/src/wfp.rs
@@ -1,17 +1,16 @@
 use std::ptr;
 
 use rama_core::{
-    error::{BoxError, ErrorExt},
+    error::{BoxError, ErrorExt, extra::OpaqueError},
     telemetry::tracing::{debug, info, warn},
 };
 use safechain_proxy_lib_nostd::windows::driver_protocol::{
     WFP_CALLOUT_SAFECHAIN_TCP_CONNECT_REDIRECT_V4, WFP_CALLOUT_SAFECHAIN_TCP_CONNECT_REDIRECT_V6,
     WFP_CALLOUT_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V4,
-    WFP_CALLOUT_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V6,
-    WFP_FILTER_SAFECHAIN_TCP_CONNECT_REDIRECT_V4, WFP_FILTER_SAFECHAIN_TCP_CONNECT_REDIRECT_V6,
-    WFP_FILTER_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V4,
-    WFP_FILTER_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V6,
-    WFP_PROVIDER_SAFECHAIN_L4_PROXY, WFP_SUBLAYER_SAFECHAIN_L4_PROXY, WindowsGuid,
+    WFP_CALLOUT_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V6, WFP_FILTER_SAFECHAIN_TCP_CONNECT_REDIRECT_V4,
+    WFP_FILTER_SAFECHAIN_TCP_CONNECT_REDIRECT_V6, WFP_FILTER_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V4,
+    WFP_FILTER_SAFECHAIN_UDP_AUTH_CONNECT_BLOCK_V6, WFP_PROVIDER_SAFECHAIN_L4_PROXY,
+    WFP_SUBLAYER_SAFECHAIN_L4_PROXY, WindowsGuid,
 };
 use windows_sys::Win32::{
     Foundation::{
@@ -388,7 +387,10 @@ fn check_delete_status(
         status = format_args!("{status:#x}"),
         "unexpected WFP delete failure"
     );
-    Err(BoxError::from("WFP (delete) operation failed").context_hex_field("status", status))
+    Err(
+        OpaqueError::from_static_str("WFP (delete) operation failed")
+            .context_hex_field("status", status),
+    )
 }
 
 fn zeroed_blob() -> FWP_BYTE_BLOB {
@@ -417,7 +419,8 @@ fn check_status(status: u32, operation: &str) -> Result<(), BoxError> {
             status = format_args!("{status:#x}"),
             "WFP operation failed"
         );
-        Err(BoxError::from("WFP operation failed").context_hex_field("status", status))
+        Err(OpaqueError::from_static_str("WFP operation failed")
+            .context_hex_field("status", status))
     }
 }
 

--- a/proxy-bin-l4/src/tcp/mod.rs
+++ b/proxy-bin-l4/src/tcp/mod.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 use rama::{
     Layer, Service,
     combinators::Either,
-    error::{BoxError, ErrorContext as _},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     http::{
@@ -329,9 +329,9 @@ async fn create_firewall(
         }
 
         _ = guard.downgrade().into_cancelled() => {
-            Err(BoxError::from(
+            Err(OpaqueError::from_static_str(
                 "shutdown initiated prior to firewall created; exit process immediately",
-            ))
+            ).into_box_error())
         }
     }
 }

--- a/proxy-bin-l4/src/tcp/proxy_target/deny.rs
+++ b/proxy-bin-l4/src/tcp/proxy_target/deny.rs
@@ -1,4 +1,9 @@
-use rama::{Layer, Service, error::BoxError, extensions::ExtensionsRef, io::Io};
+use rama::{
+    Layer, Service,
+    error::{BoxError, extra::OpaqueError},
+    extensions::ExtensionsRef,
+    io::Io,
+};
 
 #[derive(Debug, Clone)]
 pub struct DenyProxyTargetFromInputLayer;
@@ -25,10 +30,10 @@ where
     Input: Io + ExtensionsRef,
 {
     type Output = S::Output;
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     async fn serve(&self, _: Input) -> Result<Self::Output, Self::Error> {
-        Err(BoxError::from(
+        Err(OpaqueError::from_static_str(
             "Platform does not support L4 TProxy via this binary (Linux/Windows only)",
         ))
     }

--- a/proxy-bin-l7/src/main.rs
+++ b/proxy-bin-l7/src/main.rs
@@ -7,7 +7,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use rama::{
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     graceful::{self, ShutdownGuard},
     http::Uri,
     net::{
@@ -219,9 +219,9 @@ where
         }
 
         _ = graceful.guard_weak().into_cancelled() => {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "shutdown initiated prior to firewall created; exit process immediately",
-            ));
+            ).into_box_error());
         }
     };
 

--- a/proxy-bin-l7/src/server/proxy/mod.rs
+++ b/proxy-bin-l7/src/server/proxy/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     graceful::ShutdownGuard,
     http::{
         layer::{
@@ -135,10 +135,10 @@ pub async fn run_proxy_server(
     crate::server::write_server_socket_address_as_file(&args.data, "proxy", proxy_addr.into())
         .await?;
     if proxy_addr_tx.send(proxy_addr.into()).is_err() {
-        return Err(
-            BoxError::from("failed to send proxy address to meta server task")
-                .context_field("address", proxy_addr),
-        );
+        return Err(OpaqueError::from_static_str(
+            "failed to send proxy address to meta server task",
+        )
+        .context_field("address", proxy_addr));
     }
 
     // sent proxy addr to firewall

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
 use rama::{
     Layer, Service,
     combinators::Either,
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     http::{
@@ -289,9 +289,9 @@ async fn create_firewall(
         }
 
         _ = guard.downgrade().into_cancelled() => {
-            Err(BoxError::from(
+            Err(OpaqueError::from_static_str(
                 "shutdown initiated prior to firewall created; exit process immediately",
-            ))
+            ).into_box_error())
         }
     }
 }

--- a/proxy-lib/src/storage/data.rs
+++ b/proxy-lib/src/storage/data.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use rama::error::{BoxError, ErrorContext, ErrorExt as _};
+use rama::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
 use serde::{Serialize, de::DeserializeOwned};
 
 #[derive(Debug, Clone)]
@@ -17,16 +17,19 @@ pub struct SyncCompactDataStorage {
 impl SyncCompactDataStorage {
     pub fn try_new(dir: PathBuf) -> Result<Self, BoxError> {
         if dir.as_os_str().is_empty() {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "empty data storage dir value is not allowed",
-            ));
+            )
+            .into_box_error());
         }
 
         match std::fs::metadata(&dir) {
             Ok(meta) => {
                 if !meta.is_dir() {
-                    return Err(BoxError::from("data storage path is not a directory")
-                        .context_debug_field("path", dir));
+                    return Err(OpaqueError::from_static_str(
+                        "data storage path is not a directory",
+                    )
+                    .context_debug_field("path", dir));
                 }
             }
             Err(err) => {

--- a/proxy-lib/src/storage/secrets.rs
+++ b/proxy-lib/src/storage/secrets.rs
@@ -1,4 +1,5 @@
 use parking_lot::RwLock;
+use rama::error::extra::OpaqueError;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::{path::PathBuf, str::FromStr};
@@ -157,7 +158,9 @@ impl FromStr for StorageKind {
 
         let dir = PathBuf::from(s);
         if dir.as_os_str().is_empty() {
-            return Err(BoxError::from("empty secrets value is not allowed"));
+            return Err(
+                OpaqueError::from_static_str("empty secrets value is not allowed").into_box_error(),
+            );
         }
 
         let meta = std::fs::metadata(&dir)
@@ -166,7 +169,8 @@ impl FromStr for StorageKind {
 
         if !meta.is_dir() {
             return Err(
-                BoxError::from("secrets path is not a directory").context_debug_field("path", dir)
+                OpaqueError::from_static_str("secrets path is not a directory")
+                    .context_debug_field("path", dir),
             );
         }
 
@@ -386,9 +390,10 @@ fn parse_apple_protected_storage_kind(s: &str) -> Result<Option<StorageKind>, Bo
                 match key {
                     "access-group" => {
                         if value.is_empty() {
-                            return Err(BoxError::from(
+                            return Err(OpaqueError::from_static_str(
                                 "protected secrets storage requires non-empty access-group value",
-                            ));
+                            )
+                            .into_box_error());
                         }
                         access_group = Some(value.to_string());
                     }
@@ -396,23 +401,24 @@ fn parse_apple_protected_storage_kind(s: &str) -> Result<Option<StorageKind>, Bo
                         "true" => cloud_sync = true,
                         "false" => cloud_sync = false,
                         _ => {
-                            return Err(BoxError::from(
+                            return Err(OpaqueError::from_static_str(
                                 "protected secrets storage cloud-sync must be either true or false",
-                            ));
+                            )
+                            .into_box_error());
                         }
                     },
                     _ => {
-                        return Err(BoxError::from(
+                        return Err(OpaqueError::from_static_str(
                             "unsupported protected secrets option; supported: access-group, cloud-sync",
-                        ));
+                        ).into_box_error());
                     }
                 }
             } else if access_group.is_none() {
                 access_group = Some(token.to_string());
             } else {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "invalid protected secrets storage syntax; expected 'protected[:access-group=<group>][,cloud-sync=true|false]'",
-                ));
+                ).into_box_error());
             }
         }
     }

--- a/proxy-lib/src/tls/root.rs
+++ b/proxy-lib/src/tls/root.rs
@@ -1,5 +1,5 @@
 use rama::{
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     net::{address::Domain, tls::server::SelfSignedData},
     telemetry::tracing,
     tls::boring::{
@@ -83,9 +83,10 @@ fn store_crt_in_secret_storage(
     let crt_der = crt_data.crt_der();
     let chunk_count = crt_der.len().div_ceil(CRT_SECRET_CHUNK_SIZE_BYTES);
     if chunk_count == 0 {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "refusing to store empty CA crt bytes in secret storage",
-        ));
+        )
+        .into_box_error());
     }
 
     for (idx, chunk) in crt_der.chunks(CRT_SECRET_CHUNK_SIZE_BYTES).enumerate() {
@@ -117,9 +118,11 @@ fn load_crt_from_secret_storage(
     };
 
     if !crt_meta.crt_fingerprint().eq(expected_fp) {
-        return Err(BoxError::from("unexpected CA crt meta fingerprint")
-            .context_hex_field("expected_fingerprint", expected_fp.to_vec())
-            .context_hex_field("found_fingerprint", crt_meta.crt_fingerprint().to_vec()));
+        return Err(
+            OpaqueError::from_static_str("unexpected CA crt meta fingerprint")
+                .context_hex_field("expected_fingerprint", expected_fp.to_vec())
+                .context_hex_field("found_fingerprint", crt_meta.crt_fingerprint().to_vec()),
+        );
     }
 
     let mut crt_der = Vec::new();
@@ -130,8 +133,10 @@ fn load_crt_from_secret_storage(
             .context("load CA crt chunk from secret storage")
             .context_str_field("chunk_key", &chunk_key)?
         else {
-            return Err(BoxError::from("missing CA crt chunk in secret storage")
-                .context_str_field("chunk_key", &chunk_key));
+            return Err(
+                OpaqueError::from_static_str("missing CA crt chunk in secret storage")
+                    .context_str_field("chunk_key", &chunk_key),
+            );
         };
         crt_der.extend_from_slice(&chunk);
     }
@@ -172,9 +177,11 @@ pub(super) fn new_root_tls_crt_key_pair(
             .digest(MessageDigest::sha256())
             .context("recompute CA crt fingerprint from stored DER")?;
         if !crt_fp.eq(key_data.crt_fingerprint()) {
-            return Err(BoxError::from("unexpected CA crt fingerprint")
-                .context_hex_field("computed_fingerprint", crt_fp)
-                .context_hex_field("expected_fingerprint", key_data.crt_fingerprint().to_vec()));
+            return Err(
+                OpaqueError::from_static_str("unexpected CA crt fingerprint")
+                    .context_hex_field("computed_fingerprint", crt_fp)
+                    .context_hex_field("expected_fingerprint", key_data.crt_fingerprint().to_vec()),
+            );
         }
 
         let key_x509 = PKey::private_key_from_der(key_data.key())

--- a/proxy-lib/src/utils/remote_resource.rs
+++ b/proxy-lib/src/utils/remote_resource.rs
@@ -362,12 +362,12 @@ where
     if !resp.status().is_success() {
         let http_status_code = resp.status();
         let maybe_error_msg = resp.try_into_string().await.unwrap_or_default();
-        return Err(
-            BoxError::from("failed to download remote resource from remote endpoint")
-                .with_context_field("uri", || uri.clone())
-                .context_field("status", http_status_code)
-                .context_field("message", maybe_error_msg),
-        );
+        return Err(OpaqueError::from_static_str(
+            "failed to download remote resource from remote endpoint",
+        )
+        .with_context_field("uri", || uri.clone())
+        .context_field("status", http_status_code)
+        .context_field("message", maybe_error_msg));
     }
 
     let e_tag: Option<ArcStr> = resp


### PR DESCRIPTION
the latter doesn't allocate a heap String for the error, whereas the first (rust std) approach does...

rama now provides a non-alloc option :)
and this PR switches the cases where you can benefit from it to this new option

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Replaced heap-allocating BoxError::from(str) with OpaqueError::from_static_str everywhere
* Updated imports to include rama error extra::OpaqueError and ErrorExt
* Adjusted error types and context chaining to use OpaqueError and into_box_error
* Changed DenyProxyTargetFromInput service error type to OpaqueError


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106961103?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->