### PR TITLE
Patch/minor improvements main

### DIFF
--- a/proxy-lib/src/http/firewall/layer.rs
+++ b/proxy-lib/src/http/firewall/layer.rs
@@ -2,11 +2,11 @@ use rama::{
     Layer, Service,
     error::{BoxError, ErrorContext},
     extensions::ExtensionsRef,
-    http::{Request, Response, Uri},
+    http::{Request, Response},
 };
 
 use crate::{
-    http::try_get_domain_for_req,
+    http::{RequestMetaUri, try_get_domain_for_req},
     utils::net::{get_app_source_bundle_id_from_ext, get_source_process_path_from_ext},
 };
 
@@ -73,9 +73,13 @@ where
                 }
             };
 
-            let req_uri: Uri = mod_req.uri().clone();
+            mod_req
+                .extensions()
+                .insert(RequestMetaUri::from_request(&mod_req));
+
             let resp = self.inner.serve(mod_req).await.into_box_error()?;
-            Ok(http_rules.evaluate_http_response(resp, &req_uri).await?)
+
+            Ok(http_rules.evaluate_http_response(resp).await?)
         } else {
             self.inner.serve(req).await.into_box_error()
         }

--- a/proxy-lib/src/http/firewall/matched_rules.rs
+++ b/proxy-lib/src/http/firewall/matched_rules.rs
@@ -5,7 +5,7 @@ use rama::{
     error::BoxError,
     extensions::{Extension, ExtensionsRef},
     http::{
-        Request, Response, Uri,
+        Request, Response,
         ws::handshake::mitm::{WebSocketRelayDirection, WebSocketRelayInput, WebSocketRelayOutput},
     },
     matcher::service::{ServiceMatch, ServiceMatcher},
@@ -65,13 +65,12 @@ impl FirewallHttpRules {
     pub(super) async fn evaluate_http_response(
         &self,
         resp: Response,
-        req_uri: &Uri,
     ) -> Result<Response, BoxError> {
         let mut mod_resp = resp;
 
         // Iterate rules in reverse order for symmetry with request evaluation
         for rule in self.0.iter().rev() {
-            mod_resp = rule.evaluate_response(mod_resp, req_uri).await?;
+            mod_resp = rule.evaluate_response(mod_resp).await?;
         }
 
         Ok(mod_resp)

--- a/proxy-lib/src/http/firewall/rule/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/mod.rs
@@ -281,12 +281,10 @@ pub trait Rule: Sized + Send + Sync + 'static {
     ///                                      |
     ///                                      └──> Can Modify or Replace
     /// ```
-    fn evaluate_response<'r>(
-        &'r self,
+    fn evaluate_response(
+        &self,
         resp: Response,
-        req_uri: &'r Uri,
-    ) -> impl Future<Output = Result<Response, BoxError>> + Send + 'r {
-        let _ = req_uri;
+    ) -> impl Future<Output = Result<Response, BoxError>> + Send + '_ {
         std::future::ready(Ok(resp))
     }
 
@@ -328,11 +326,10 @@ trait DynRuleInner {
         req: Request,
     ) -> Pin<Box<dyn Future<Output = Result<RequestAction, BoxError>> + Send + '_>>;
 
-    fn dyn_evaluate_response<'r>(
-        &'r self,
+    fn dyn_evaluate_response(
+        &self,
         resp: Response,
-        req_uri: &'r Uri,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'r>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + '_>>;
 
     fn dyn_match_domain(&self, domain: &Domain) -> bool;
 
@@ -371,12 +368,11 @@ impl<R: Rule> DynRuleInner for R {
 
     #[inline(always)]
     /// see [`Rule::evaluate_response`] for more information.
-    fn dyn_evaluate_response<'r>(
-        &'r self,
+    fn dyn_evaluate_response(
+        &self,
         resp: Response,
-        req_uri: &'r Uri,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'r>> {
-        Box::pin(self.evaluate_response(resp, req_uri))
+    ) -> Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + '_>> {
+        Box::pin(self.evaluate_response(resp))
     }
 
     #[inline(always)]
@@ -461,12 +457,11 @@ impl Rule for DynRule {
     }
 
     #[inline(always)]
-    fn evaluate_response<'r>(
-        &'r self,
+    fn evaluate_response(
+        &self,
         resp: Response,
-        req_uri: &'r Uri,
-    ) -> impl Future<Output = Result<Response, BoxError>> + Send + 'r {
-        self.inner.dyn_evaluate_response(resp, req_uri)
+    ) -> impl Future<Output = Result<Response, BoxError>> + Send + '_ {
+        self.inner.dyn_evaluate_response(resp)
     }
 
     #[inline(always)]

--- a/proxy-lib/src/http/firewall/rule/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/mod.rs
@@ -5,11 +5,7 @@ use rama::{
     extensions::{Extensions, ExtensionsRef as _},
     http::{
         Method, Request, Response, StatusCode, Uri, Version,
-        header::{self, HeaderMap, HeaderValue},
-        headers::{CacheControl, HeaderMapExt as _},
-        layer::remove_header::{
-            remove_cache_policy_headers, remove_cache_validation_response_headers,
-        },
+        header::{HeaderMap, HeaderValue},
         request,
         ws::handshake::mitm::{WebSocketRelayDirection, WebSocketRelayOutput},
     },
@@ -48,17 +44,6 @@ pub(crate) fn block_reason_for(decision: PackagePolicyDecision) -> BlockReason {
             unreachable!("Allow and Defer are not blocking decisions")
         }
     }
-}
-
-/// Strips all caching headers and inserts `Cache-Control: no-cache`.
-///
-/// Used by min-package-age rules after rewriting a response body so that
-/// the client cannot serve a stale, unfiltered copy from its own cache.
-pub(in crate::http::firewall) fn make_response_uncacheable(headers: &mut HeaderMap) {
-    remove_cache_policy_headers(headers);
-    remove_cache_validation_response_headers(headers);
-    headers.remove(header::CONTENT_LENGTH);
-    headers.typed_insert(CacheControl::new().with_no_cache());
 }
 
 #[cfg(feature = "pac")]

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
@@ -19,6 +19,7 @@ use crate::{
             notifier::EventNotifier,
             rule::npm::NPM_ECOSYSTEM_KEY,
         },
+        headers::make_response_uncacheable,
     },
     utils::time::{SystemDuration, SystemTimestampMilliseconds},
 };
@@ -103,7 +104,7 @@ impl MinPackageAge {
         let new_bytes =
             serde_json::to_vec(&json).context("serialize modified npm info response")?;
 
-        super::super::make_response_uncacheable(&mut parts.headers);
+        make_response_uncacheable(&mut parts.headers);
 
         if let Some(notifier) = &self.notifier {
             let event = MinPackageAgeEvent {

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -146,11 +146,7 @@ impl Rule for RuleNpm {
     }
 
     #[inline(always)]
-    async fn evaluate_response(
-        &self,
-        resp: Response,
-        _req_uri: &Uri,
-    ) -> Result<Response, BoxError> {
+    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => min_package_age.remove_new_packages(resp).await,
             None => Ok(resp),

--- a/proxy-lib/src/http/firewall/rule/nuget/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/nuget/mod.rs
@@ -188,11 +188,7 @@ impl Rule for RuleNuget {
     }
 
     #[inline(always)]
-    async fn evaluate_response(
-        &self,
-        resp: Response,
-        _req_uri: &Uri,
-    ) -> Result<Response, BoxError> {
+    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         Ok(resp)
     }
 

--- a/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/min_package_age/mod.rs
@@ -16,6 +16,7 @@ use crate::{
             events::{Artifact, MinPackageAgeEvent},
             notifier::EventNotifier,
         },
+        headers::make_response_uncacheable,
     },
     package::{
         name_formatter::LowerCasePackageName, released_packages_list::RemoteReleasedPackagesList,
@@ -81,7 +82,7 @@ impl MinPackageAgePyPI {
                     "PyPI metadata rewritten: suppressed too-young versions"
                 );
 
-                super::super::make_response_uncacheable(&mut parts.headers);
+                make_response_uncacheable(&mut parts.headers);
                 self.notify_rewrite(&rewrite).await;
 
                 Ok(Response::from_parts(parts, Body::from(rewrite.bytes)))
@@ -93,7 +94,7 @@ impl MinPackageAgePyPI {
                 // HTML is streamed through lol_html without buffering the full body.
                 // Cache headers are stripped upfront because we cannot defer
                 // header writes until the body is fully consumed.
-                super::super::make_response_uncacheable(&mut parts.headers);
+                make_response_uncacheable(&mut parts.headers);
 
                 let notifier = self.notifier.clone();
                 let streaming_body = html::rewrite_body(

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -225,11 +225,7 @@ impl Rule for RulePyPI {
     }
 
     #[inline(always)]
-    async fn evaluate_response(
-        &self,
-        resp: Response,
-        _req_uri: &Uri,
-    ) -> Result<Response, BoxError> {
+    async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
                 min_package_age

--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -1,3 +1,22 @@
-use rama::http::HeaderName;
+use rama::http::{
+    HeaderMap, HeaderName,
+    headers::{CacheControl, HeaderMapExt as _},
+    layer::remove_header::{
+        remove_cache_policy_headers, remove_cache_validation_response_headers,
+        remove_payload_metadata_headers,
+    },
+};
 
 pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");
+
+/// Strips all caching headers and inserts `Cache-Control: no-cache`.
+///
+/// Example use case is (firewall) min-package-age rules after
+/// rewriting a response body so that the client cannot serve a stale,
+/// unfiltered copy from its own cache.
+pub fn make_response_uncacheable(headers: &mut HeaderMap) {
+    remove_cache_policy_headers(headers);
+    remove_cache_validation_response_headers(headers);
+    remove_payload_metadata_headers(headers);
+    headers.typed_insert(CacheControl::new().with_no_cache());
+}

--- a/proxy-lib/src/http/mod.rs
+++ b/proxy-lib/src/http/mod.rs
@@ -9,7 +9,7 @@ mod lol_html_body;
 pub(crate) use lol_html_body::LolHtmlBody;
 
 mod req_info;
-pub use req_info::try_get_domain_for_req;
+pub use req_info::{RequestMetaHeaders, RequestMetaUri, try_get_domain_for_req};
 
 pub mod client;
 

--- a/proxy-lib/src/http/req_info.rs
+++ b/proxy-lib/src/http/req_info.rs
@@ -8,13 +8,11 @@ use rama::{
 
 macro_rules! request_meta_type {
     ($name:ident, $t:ty) => {
-        #[derive(Debug)]
+        #[derive(Debug, Extension)]
         /// meta information that can be stored as extension data in a request,
         /// such that it is also available for later use while processing
         /// its response.
         pub struct $name(pub $t);
-
-        impl Extension for $name {}
     };
 }
 

--- a/proxy-lib/src/http/req_info.rs
+++ b/proxy-lib/src/http/req_info.rs
@@ -6,17 +6,11 @@ use rama::{
     net::{address::Domain, http::RequestContext, proxy::ProxyTarget},
 };
 
-macro_rules! request_meta_type {
-    ($name:ident, $t:ty) => {
-        #[derive(Debug, Extension)]
-        /// meta information that can be stored as extension data in a request,
-        /// such that it is also available for later use while processing
-        /// its response.
-        pub struct $name(pub $t);
-    };
-}
-
-request_meta_type!(RequestMetaUri, Uri);
+#[derive(Debug, Extension)]
+/// Original uri from request, can be useful
+/// to store as request Extension info such that you have
+/// access to it in a later layer or even while processing its response.
+pub struct RequestMetaUri(pub Uri);
 
 impl RequestMetaUri {
     #[inline(always)]
@@ -25,7 +19,11 @@ impl RequestMetaUri {
     }
 }
 
-request_meta_type!(RequestMetaHeaders, HeaderMap);
+#[derive(Debug, Extension)]
+/// Original http headers from request, can be useful
+/// to store as request Extension info such that you have
+/// access to it in a later layer or even while processing its response.
+pub struct RequestMetaHeaders(pub HeaderMap);
 
 impl RequestMetaHeaders {
     #[inline(always)]

--- a/proxy-lib/src/http/req_info.rs
+++ b/proxy-lib/src/http/req_info.rs
@@ -1,10 +1,40 @@
 use std::borrow::Cow;
 
 use rama::{
-    extensions::ExtensionsRef,
-    http::Request,
+    extensions::{Extension, ExtensionsRef},
+    http::{HeaderMap, Request, Uri, utils::request_uri},
     net::{address::Domain, http::RequestContext, proxy::ProxyTarget},
 };
+
+macro_rules! request_meta_type {
+    ($name:ident, $t:ty) => {
+        #[derive(Debug)]
+        /// meta information that can be stored as extension data in a request,
+        /// such that it is also available for later use while processing
+        /// its response.
+        pub struct $name(pub $t);
+
+        impl Extension for $name {}
+    };
+}
+
+request_meta_type!(RequestMetaUri, Uri);
+
+impl RequestMetaUri {
+    #[inline(always)]
+    pub fn from_request<Body>(req: &Request<Body>) -> Self {
+        Self(request_uri(req).into_owned())
+    }
+}
+
+request_meta_type!(RequestMetaHeaders, HeaderMap);
+
+impl RequestMetaHeaders {
+    #[inline(always)]
+    pub fn from_request<Body>(req: &Request<Body>) -> Self {
+        Self(req.headers().clone())
+    }
+}
 
 pub fn try_get_domain_for_req<Body>(req: &Request<Body>) -> Option<Cow<'_, Domain>> {
     if let Some(ProxyTarget(target)) = req.extensions().get_ref()
@@ -21,41 +51,5 @@ pub fn try_get_domain_for_req<Body>(req: &Request<Body>) -> Option<Cow<'_, Domai
 }
 
 #[cfg(test)]
-mod tests {
-    use rama::http::Body;
-
-    use super::*;
-
-    #[test]
-    fn test_try_get_domain_for_req() {
-        struct TestCase {
-            req: Request,
-            expected_domain: Option<String>,
-        }
-
-        for test_case in [
-            TestCase {
-                req: Request::new(Body::empty()),
-                expected_domain: None,
-            },
-            TestCase {
-                req: Request::builder()
-                    .uri("http://example.com/foo")
-                    .body(Body::empty())
-                    .unwrap(),
-                expected_domain: Some("example.com".to_owned()),
-            },
-            TestCase {
-                req: Request::builder()
-                    .uri("/foo")
-                    .extension(ProxyTarget((Domain::from_static("aikido.dev"), 443).into()))
-                    .body(Body::empty())
-                    .unwrap(),
-                expected_domain: Some("aikido.dev".to_owned()),
-            },
-        ] {
-            let result = try_get_domain_for_req(&test_case.req).map(|d| d.to_string());
-            assert_eq!(test_case.expected_domain, result);
-        }
-    }
-}
+#[path = "req_info_tests.rs"]
+mod tests;

--- a/proxy-lib/src/http/req_info_tests.rs
+++ b/proxy-lib/src/http/req_info_tests.rs
@@ -1,0 +1,93 @@
+use std::convert::Infallible;
+
+use rama::{
+    Service,
+    http::{Body, Response, Uri, proto::RequestExtensions, server::HttpServer},
+    net::test_utils::client::MockConnectorService,
+    rt::Executor,
+    service::service_fn,
+};
+
+use super::*;
+
+const REQUEST_META_TEST_URI: &str = "http://example.com/foo?bar=baz";
+const REQUEST_META_TEST_HEADER_NAME: &str = "x-request-meta-test";
+const REQUEST_META_TEST_HEADER_VALUE: &str = "present";
+
+#[test]
+fn test_try_get_domain_for_req() {
+    struct TestCase {
+        req: Request,
+        expected_domain: Option<String>,
+    }
+
+    for test_case in [
+        TestCase {
+            req: Request::new(Body::empty()),
+            expected_domain: None,
+        },
+        TestCase {
+            req: Request::builder()
+                .uri("http://example.com/foo")
+                .body(Body::empty())
+                .unwrap(),
+            expected_domain: Some("example.com".to_owned()),
+        },
+        TestCase {
+            req: Request::builder()
+                .uri("/foo")
+                .extension(ProxyTarget((Domain::from_static("aikido.dev"), 443).into()))
+                .body(Body::empty())
+                .unwrap(),
+            expected_domain: Some("aikido.dev".to_owned()),
+        },
+    ] {
+        let result = try_get_domain_for_req(&test_case.req).map(|d| d.to_string());
+        assert_eq!(test_case.expected_domain, result);
+    }
+}
+
+#[tokio::test]
+async fn test_request_meta() {
+    let expected_uri = Uri::from_static(REQUEST_META_TEST_URI);
+
+    let mut connector = MockConnectorService::new(|| {
+        HttpServer::auto(Executor::default()).service(service_fn(|_req: Request| async move {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        }))
+    });
+    connector.set_executor(Executor::default());
+
+    let client = crate::http::client::new_http_client_for_internal_with_connector(
+        Executor::default(),
+        connector,
+    )
+    .unwrap();
+
+    let req = Request::builder().uri(expected_uri.clone()).header(
+        REQUEST_META_TEST_HEADER_NAME,
+        REQUEST_META_TEST_HEADER_VALUE,
+    );
+    let req = req.body(Body::empty()).unwrap();
+    let request_meta_uri = RequestMetaUri::from_request(&req);
+    let request_meta_headers = RequestMetaHeaders::from_request(&req);
+    let (parts, body) = req.into_parts();
+    parts.extensions.insert(request_meta_uri);
+    parts.extensions.insert(request_meta_headers);
+    let req = Request::from_parts(parts, body);
+
+    let res = client.serve(req).await.unwrap();
+    let request_extensions = res.extensions().get_ref::<RequestExtensions>().unwrap();
+
+    assert_eq!(
+        request_extensions.get_ref().map(|RequestMetaUri(uri)| uri),
+        Some(&expected_uri),
+    );
+    assert_eq!(
+        request_extensions
+            .get_ref()
+            .and_then(|RequestMetaHeaders(headers)| headers.get(REQUEST_META_TEST_HEADER_NAME))
+            .and_then(|value| value.to_str().ok()),
+        Some(REQUEST_META_TEST_HEADER_VALUE),
+    );
+}


### PR DESCRIPTION
-  move make_response_uncacheable util to http headers + improve
    - improvement for https://github.com/AikidoSec/safechain-internals/pull/318
-  cleanup recent introduction in main regarding req uri
    - simply store it in extensions, it will be available
      in the response extensions just fine... the http core client
      handles this kind of stuff for you :)
    - improvement for https://github.com/AikidoSec/safechain-internals/pull/319

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Moved and improved make_response_uncacheable into http headers

**🔧 Refactors**
* Introduced RequestMetaUri and RequestMetaHeaders request extensions using derive
* Removed req_uri parameter from rule evaluate_response and updated callers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107018295?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->