### PR TITLE
Update HeartbeatReportInterval to 3 minutes in constants.go

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,7 +7,7 @@ const (
 	LogRotationSizeInBytes  = 10 * 1024 * 1024 // 10 MB
 	LogReapingAgeInHours    = 24               // 24 hours
 	DaemonStatusLogInterval = 1 * time.Hour
-	HeartbeatReportInterval = 10 * time.Minute
+	HeartbeatReportInterval = 3 * time.Minute
 	SBOMReportInterval      = 24 * time.Hour
 	ProxyStartMaxRetries    = 100
 )


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Reduced HeartbeatReportInterval constant from ten minutes to three minutes.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107038733?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->