### PR TITLE
Show "system setup required" on main dashboard when setup is incomplete

### DIFF
--- a/ui/daemonservice.go
+++ b/ui/daemonservice.go
@@ -94,6 +94,14 @@ func (s *DaemonService) SetupRestart() error {
 	return daemon.SetupRestart()
 }
 
+func (s *DaemonService) SetupCheck() (bool, error) {
+	return daemon.SetupCheck()
+}
+
+func (s *DaemonService) SetupStart() error {
+	return daemon.SetupStart()
+}
+
 // CloseInstallWindow hides the certificate install window.
 func (s *DaemonService) CloseInstallWindow() {
 	if closeInstallWindow != nil {

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -120,27 +120,11 @@ body {
   margin: 0 0 20px;
 }
 
-.events-list-setup-required__text {
+.events-list .events-list-setup-required__text {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.5;
   color: #7a1919;
-}
-
-.events-list-setup-required__link {
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  color: var(--surface-red-100);
-  font-weight: 600;
-  cursor: pointer;
-  text-decoration: underline;
-  font: inherit;
-}
-
-.events-list-setup-required__link:hover {
-  color: #991b1b;
 }
 
 .app-tabs {

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -71,11 +71,76 @@ body {
   display: block;
 }
 
-.app-version {
+.app-header-right {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.app-version {
   font-size: 12px;
   font-weight: 500;
   color: var(--carbon-60);
+}
+
+.app-setup-required-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface-red-20);
+  color: var(--surface-red-100);
+  border: 1px solid var(--surface-red-100);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  font-family: inherit;
+  line-height: 1.2;
+}
+
+.app-setup-required-btn:hover {
+  background: var(--surface-red-100);
+  color: #fff;
+}
+
+.app-setup-required-btn__icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.events-list-setup-required {
+  background: var(--surface-red-20);
+  border: 1px solid #f5c2c2;
+  border-left: 4px solid var(--surface-red-100);
+  border-radius: 8px;
+  padding: 14px 18px;
+  margin: 0 0 20px;
+}
+
+.events-list-setup-required__text {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #7a1919;
+}
+
+.events-list-setup-required__link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: var(--surface-red-100);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+}
+
+.events-list-setup-required__link:hover {
+  color: #991b1b;
 }
 
 .app-tabs {

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { HashRouter, Routes, Route, NavLink, useNavigate, Outlet, useLocation } from "react-router-dom";
+import { HashRouter, Routes, Route, NavLink, useNavigate, Outlet, useLocation, useOutletContext } from "react-router-dom";
 import { Events } from "@wailsio/runtime";
 import { EventsList } from "./pages/EventsList";
 import { EventDetail } from "./pages/EventDetail";
@@ -7,9 +7,18 @@ import { TlsEventsList } from "./pages/TlsEventsList";
 import { TlsEventDetail } from "./pages/TlsEventDetail";
 import { ProtectedEcosystems } from "./pages/ProtectedEcosystems";
 import { InstallPage } from "./pages/InstallPage";
-import { getVersion } from "./api";
+import { getVersion, setupCheck, setupStart } from "./api";
 import logoUrl from "../assets/logo.svg";
 import "./App.css";
+
+export type DashboardContext = {
+  setupRequired: boolean;
+  onStartSetup: () => void;
+};
+
+export function useDashboardContext(): DashboardContext {
+  return useOutletContext<DashboardContext>();
+}
 
 function FocusHandler() {
   const navigate = useNavigate();
@@ -37,9 +46,32 @@ function FocusHandler() {
 function DashboardLayout() {
   const location = useLocation();
   const [version, setVersion] = useState("");
+  const [setupRequired, setSetupRequired] = useState(false);
   useEffect(() => {
     getVersion().then(setVersion).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setupCheck()
+      .then((ok) => {
+        if (!cancelled) setSetupRequired(!ok);
+      })
+      .catch(() => {});
+    const unsub = Events.On("setup_state", (ev: { data?: { setupRequired?: boolean } }) => {
+      if (typeof ev.data?.setupRequired === "boolean") {
+        setSetupRequired(ev.data.setupRequired);
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  const onStartSetup = () => {
+    setupStart().catch(() => {});
+  };
 
   const eventsTabActive = location.pathname === "/" || location.pathname.startsWith("/events");
 
@@ -47,7 +79,19 @@ function DashboardLayout() {
     <div className="container">
       <header className="app-header">
         <img src={logoUrl} alt="Aikido" className="app-logo-img" />
-        {version && <span className="app-version">v{version}</span>}
+        <div className="app-header-right">
+          {setupRequired && (
+            <button
+              type="button"
+              className="app-setup-required-btn"
+              onClick={onStartSetup}
+            >
+              <span className="app-setup-required-btn__icon" aria-hidden>⚠</span>
+              System Setup Required…
+            </button>
+          )}
+          {version && <span className="app-version">v{version}</span>}
+        </div>
       </header>
       <nav className="app-tabs">
         <NavLink to="/events" className={() => `app-tab${eventsTabActive ? " app-tab--active" : ""}`}>
@@ -65,7 +109,7 @@ function DashboardLayout() {
       </nav>
       <main className="dashboard">
         <FocusHandler />
-        <Outlet />
+        <Outlet context={{ setupRequired, onStartSetup } satisfies DashboardContext} />
       </main>
     </div>
   );

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -87,7 +87,7 @@ function DashboardLayout() {
               onClick={onStartSetup}
             >
               <span className="app-setup-required-btn__icon" aria-hidden>⚠</span>
-              System Setup Required…
+              System Setup Required
             </button>
           )}
           {version && <span className="app-version">v{version}</span>}

--- a/ui/frontend/src/api.ts
+++ b/ui/frontend/src/api.ts
@@ -75,6 +75,14 @@ export async function setupRestart(): Promise<void> {
   return DaemonService.SetupRestart();
 }
 
+export async function setupCheck(): Promise<boolean> {
+  return DaemonService.SetupCheck();
+}
+
+export async function setupStart(): Promise<void> {
+  return DaemonService.SetupStart();
+}
+
 export async function closeInstallWindow(): Promise<void> {
   return DaemonService.CloseInstallWindow();
 }

--- a/ui/frontend/src/pages/EventsList.tsx
+++ b/ui/frontend/src/pages/EventsList.tsx
@@ -5,6 +5,7 @@ import { Events } from "@wailsio/runtime";
 import { listEvents } from "../api";
 import { BLOCK_REASON_LABEL, getToolIcon } from "../constants";
 import { formatEventTimeShort, isConnectionError } from "../utils";
+import { useDashboardContext } from "../App";
 
 function updateEventInList(events: BlockEvent[], updated: BlockEvent): BlockEvent[] {
   return events.map((event) => (event.id === updated.id ? updated : event));
@@ -12,6 +13,7 @@ function updateEventInList(events: BlockEvent[], updated: BlockEvent): BlockEven
 
 export function EventsList() {
   const navigate = useNavigate();
+  const { setupRequired, onStartSetup } = useDashboardContext();
   const [events, setEvents] = useState<BlockEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -69,6 +71,21 @@ export function EventsList() {
   return (
     <div className="events-list">
       <h1>Events</h1>
+      {setupRequired && (
+        <div className="events-list-setup-required" role="alert">
+          <p className="events-list-setup-required__text">
+            Initial setup is incomplete. Aikido Endpoint Protection is not protecting this device yet —{" "}
+            <button
+              type="button"
+              className="events-list-setup-required__link"
+              onClick={onStartSetup}
+            >
+              click “System Setup Required…”
+            </button>{" "}
+            to finish configuration.
+          </p>
+        </div>
+      )}
       {loading && <p className="events-list-loading">Loading…</p>}
       {error && !connectionFailed && (
         <div className="events-list-error-inline">

--- a/ui/frontend/src/pages/EventsList.tsx
+++ b/ui/frontend/src/pages/EventsList.tsx
@@ -13,7 +13,7 @@ function updateEventInList(events: BlockEvent[], updated: BlockEvent): BlockEven
 
 export function EventsList() {
   const navigate = useNavigate();
-  const { setupRequired, onStartSetup } = useDashboardContext();
+  const { setupRequired } = useDashboardContext();
   const [events, setEvents] = useState<BlockEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -74,15 +74,8 @@ export function EventsList() {
       {setupRequired && (
         <div className="events-list-setup-required" role="alert">
           <p className="events-list-setup-required__text">
-            Initial setup is incomplete. Aikido Endpoint Protection is not protecting this device yet —{" "}
-            <button
-              type="button"
-              className="events-list-setup-required__link"
-              onClick={onStartSetup}
-            >
-              click “System Setup Required…”
-            </button>{" "}
-            to finish configuration.
+            Initial setup is incomplete. Aikido Endpoint Protection is not protecting this device yet.
+            Click “System Setup Required” to finish configuration.
           </p>
         </div>
       )}

--- a/ui/main.go
+++ b/ui/main.go
@@ -267,15 +267,6 @@ func wrapText(text string, maxWidth int) []string {
 
 const maxStatusLines = 4
 
-// setupStart kicks off the daemon setup flow; shared between tray menu and UI button.
-func setupStart() {
-	go func() {
-		if err := daemon.SetupStart(); err != nil {
-			log.Printf("setup start: %v", err)
-		}
-	}()
-}
-
 func setupSystemTray(app *application.App, showDashboard func()) chan<- appserver.ProxyStatusBody {
 	systray := app.SystemTray.New()
 	systray.SetTooltip("Aikido Endpoint Protection")
@@ -298,7 +289,11 @@ func setupSystemTray(app *application.App, showDashboard func()) chan<- appserve
 	setupItem := menu.Add("⚠ System Setup Required...")
 	setupItem.SetHidden(true)
 	setupItem.OnClick(func(_ *application.Context) {
-		setupStart()
+		go func() {
+			if err := daemon.SetupStart(); err != nil {
+				log.Printf("setup start: %v", err)
+			}
+		}()
 	})
 	menu.AddSeparator()
 	menu.Add("Open Dashboard").OnClick(func(_ *application.Context) {

--- a/ui/main.go
+++ b/ui/main.go
@@ -33,12 +33,17 @@ var closeInstallWindow func()
 
 var setInstallWindowOnTop func(bool)
 
+type SetupStatePayload struct {
+	SetupRequired bool `json:"setupRequired"`
+}
+
 func init() {
 	application.RegisterEvent[daemon.BlockEvent]("blocked")
 	application.RegisterEvent[daemon.BlockEvent]("blocked_updated")
 	application.RegisterEvent[daemon.TlsTerminationFailedEvent]("tls_termination_failed")
 	application.RegisterEvent[daemon.PermissionsResponse]("permissions_updated")
 	application.RegisterEvent[FocusEventPayload]("focus_event")
+	application.RegisterEvent[SetupStatePayload]("setup_state")
 }
 
 // --- CLI flags -----------------------------------------------------------
@@ -262,6 +267,15 @@ func wrapText(text string, maxWidth int) []string {
 
 const maxStatusLines = 4
 
+// setupStart kicks off the daemon setup flow; shared between tray menu and UI button.
+func setupStart() {
+	go func() {
+		if err := daemon.SetupStart(); err != nil {
+			log.Printf("setup start: %v", err)
+		}
+	}()
+}
+
 func setupSystemTray(app *application.App, showDashboard func()) chan<- appserver.ProxyStatusBody {
 	systray := app.SystemTray.New()
 	systray.SetTooltip("Aikido Endpoint Protection")
@@ -284,11 +298,7 @@ func setupSystemTray(app *application.App, showDashboard func()) chan<- appserve
 	setupItem := menu.Add("⚠ System Setup Required...")
 	setupItem.SetHidden(true)
 	setupItem.OnClick(func(_ *application.Context) {
-		go func() {
-			if err := daemon.SetupStart(); err != nil {
-				log.Printf("setup start: %v", err)
-			}
-		}()
+		setupStart()
 	})
 	menu.AddSeparator()
 	menu.Add("Open Dashboard").OnClick(func(_ *application.Context) {
@@ -314,6 +324,7 @@ func setupSystemTray(app *application.App, showDashboard func()) chan<- appserve
 				setupHidden.Store(shouldHide)
 				setupItem.SetHidden(shouldHide)
 				menu.Update()
+				app.Event.Emit("setup_state", SetupStatePayload{SetupRequired: !shouldHide})
 			}
 			time.Sleep(10 * time.Second)
 		}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Exposed daemon setupCheck and setupStart methods through frontend bindings.
* Integrated setup state into dashboard and added header setup button.
* Displayed informative setup-required message on EventsList when setup incomplete.

**🔧 Refactors**
* Registered setup_state event and adjusted main window and tray handling.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107451052?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

<img width="694" height="578" alt="image" src="https://github.com/user-attachments/assets/e86b27c4-e31c-4c4d-bddc-adbff8756e64" />
