### PR TITLE
Fix regression: don't remove encoding headers in make_response_uncacheable

### DIFF
--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -14,6 +14,8 @@ pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");
 pub fn make_response_uncacheable(headers: &mut HeaderMap) {
     remove_cache_policy_headers(headers);
     remove_cache_validation_response_headers(headers);
-    headers.remove(header::CONTENT_LENGTH);
+    while headers.remove([header](header::CONTENT_LENGTH)).is_some() {
+        tracing::trace!("removed content-length http header");
+    }
     headers.typed_insert(CacheControl::new().with_no_cache());
 }

--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -14,7 +14,7 @@ pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");
 pub fn make_response_uncacheable(headers: &mut HeaderMap) {
     remove_cache_policy_headers(headers);
     remove_cache_validation_response_headers(headers);
-    while headers.remove([header](header::CONTENT_LENGTH)).is_some() {
+    while headers.remove(header::CONTENT_LENGTH).is_some() {
         tracing::trace!("removed content-length http header");
     }
     headers.typed_insert(CacheControl::new().with_no_cache());

--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -14,8 +14,6 @@ pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");
 pub fn make_response_uncacheable(headers: &mut HeaderMap) {
     remove_cache_policy_headers(headers);
     remove_cache_validation_response_headers(headers);
-    while headers.remove(header::CONTENT_LENGTH).is_some() {
-        tracing::trace!("removed content-length http header");
-    }
+    while headers.remove(header::CONTENT_LENGTH).is_some() {}
     headers.typed_insert(CacheControl::new().with_no_cache());
 }

--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -1,9 +1,9 @@
 use rama::http::{
     HeaderMap, HeaderName,
+    header,
     headers::{CacheControl, HeaderMapExt as _},
     layer::remove_header::{
         remove_cache_policy_headers, remove_cache_validation_response_headers,
-        remove_payload_metadata_headers,
     },
 };
 
@@ -17,6 +17,6 @@ pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");
 pub fn make_response_uncacheable(headers: &mut HeaderMap) {
     remove_cache_policy_headers(headers);
     remove_cache_validation_response_headers(headers);
-    remove_payload_metadata_headers(headers);
+    headers.remove(header::CONTENT_LENGTH);
     headers.typed_insert(CacheControl::new().with_no_cache());
 }

--- a/proxy-lib/src/http/headers.rs
+++ b/proxy-lib/src/http/headers.rs
@@ -1,10 +1,7 @@
 use rama::http::{
-    HeaderMap, HeaderName,
-    header,
+    HeaderMap, HeaderName, header,
     headers::{CacheControl, HeaderMapExt as _},
-    layer::remove_header::{
-        remove_cache_policy_headers, remove_cache_validation_response_headers,
-    },
+    layer::remove_header::{remove_cache_policy_headers, remove_cache_validation_response_headers},
 };
 
 pub const X_DEVICE_ID: HeaderName = HeaderName::from_static("x-device-id");


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced remove_payload_metadata_headers call with explicit CONTENT_LENGTH removal loop

**🔧 Refactors**
* Refactored imports to include header and simplify remove_header imports


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107488115?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->