### PR TITLE
Reshow setup wizard after 24hours if not completed & run certificate configuration async

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,13 +16,13 @@ const (
 )
 
 type ConfigInfo struct {
-	Token                   string    `json:"token"`
-	DeviceID                string    `json:"device_id"`
+	Token                    string    `json:"token"`
+	DeviceID                 string    `json:"device_id"`
 	LastHeartbeatReportTime  time.Time `json:"last_heartbeat_report_time"`
 	LastSBOMReportTime       time.Time `json:"last_sbom_report_time"`
 	LastSetupWizardShownTime time.Time `json:"last_setup_wizard_shown_time"`
-	BaseURL                 string    `json:"base_url,omitempty"`
-	ProxyMode               string    `json:"proxy_mode,omitempty"`
+	BaseURL                  string    `json:"base_url,omitempty"`
+	ProxyMode                string    `json:"proxy_mode,omitempty"`
 
 	LastHandledLogCollectRequestAt int64  `json:"last_handled_log_collect_request_at,omitempty"`
 	LastHandledTargetUpdateVersion string `json:"last_handled_target_update_version,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,9 @@ const (
 type ConfigInfo struct {
 	Token                   string    `json:"token"`
 	DeviceID                string    `json:"device_id"`
-	LastHeartbeatReportTime time.Time `json:"last_heartbeat_report_time"`
-	LastSBOMReportTime      time.Time `json:"last_sbom_report_time"`
+	LastHeartbeatReportTime  time.Time `json:"last_heartbeat_report_time"`
+	LastSBOMReportTime       time.Time `json:"last_sbom_report_time"`
+	LastSetupWizardShownTime time.Time `json:"last_setup_wizard_shown_time"`
 	BaseURL                 string    `json:"base_url,omitempty"`
 	ProxyMode               string    `json:"proxy_mode,omitempty"`
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -3,12 +3,12 @@ package constants
 import "time"
 
 const (
-	DaemonHeartbeatInterval = 15 * time.Second // Interval at which the daemon will check the if proxy and scanners are running
-	LogRotationSizeInBytes  = 10 * 1024 * 1024 // 10 MB
-	LogReapingAgeInHours    = 24               // 24 hours
-	DaemonStatusLogInterval = 1 * time.Hour
-	HeartbeatReportInterval = 3 * time.Minute
-	SBOMReportInterval      = 24 * time.Hour
+	DaemonHeartbeatInterval   = 15 * time.Second // Interval at which the daemon will check the if proxy and scanners are running
+	LogRotationSizeInBytes    = 10 * 1024 * 1024 // 10 MB
+	LogReapingAgeInHours      = 24               // 24 hours
+	DaemonStatusLogInterval   = 1 * time.Hour
+	HeartbeatReportInterval   = 3 * time.Minute
+	SBOMReportInterval        = 24 * time.Hour
 	SetupWizardReshowInterval = 24 * time.Hour
-	ProxyStartMaxRetries    = 100
+	ProxyStartMaxRetries      = 100
 )

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,5 +9,6 @@ const (
 	DaemonStatusLogInterval = 1 * time.Hour
 	HeartbeatReportInterval = 3 * time.Minute
 	SBOMReportInterval      = 24 * time.Hour
+	SetupWizardReshowInterval = 24 * time.Hour
 	ProxyStartMaxRetries    = 100
 )

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -59,6 +59,8 @@ type Daemon struct {
 }
 
 func New(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) {
+	uiMgr := NewUIManager()
+
 	if err := platform.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize platform: %v", err)
 	}
@@ -74,8 +76,6 @@ func New(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("failed to create config")
 	}
-
-	uiMgr := NewUIManager()
 
 	var proxyManager proxy.ProxyManager
 	if cfg.GetProxyMode() == config.ProxyModeL4 {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -490,11 +490,7 @@ func (d *Daemon) reportHeartbeat() error {
 	d.handleTargetUpdateVersion(resp)
 
 	d.runIfIntervalExceeded(&d.config.LastSetupWizardShownTime, constants.SetupWizardReshowInterval, func() error {
-		steps := ingress.ComputeSetupSteps(d.ctx, d.config)
-		if len(steps) == 0 {
-			return nil
-		}
-		d.uiManager.StartSetupWizard(steps)
+		d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
 		return nil
 	})
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -57,8 +57,6 @@ type Daemon struct {
 }
 
 func New(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) {
-	uiMgr := NewUIManager()
-
 	if err := platform.Init(); err != nil {
 		return nil, fmt.Errorf("failed to initialize platform: %v", err)
 	}
@@ -74,6 +72,8 @@ func New(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("failed to create config")
 	}
+
+	uiMgr := NewUIManager(cfg)
 
 	var proxyManager proxy.ProxyManager
 	if cfg.GetProxyMode() == config.ProxyModeL4 {
@@ -476,6 +476,15 @@ func (d *Daemon) heartbeat() error {
 		if err := d.reportSBOM(); err != nil {
 			return fmt.Errorf("Failed to report SBOM: %v", err)
 		}
+		return nil
+	})
+
+	d.runIfIntervalExceeded(&d.config.LastSetupWizardShownTime, constants.SetupWizardReshowInterval, func() error {
+		steps := ingress.ComputeSetupSteps(d.ctx, d.config)
+		if len(steps) == 0 {
+			return nil
+		}
+		d.uiManager.StartSetupWizard(steps)
 		return nil
 	})
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -229,7 +229,7 @@ func (d *Daemon) run(ctx context.Context) error {
 		}
 
 		if !proxy.ProxyCAInstalled() {
-			d.uiManager.StartSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
+			d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
 		}
 	}()
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -73,7 +73,7 @@ func New(ctx context.Context, cancel context.CancelFunc) (*Daemon, error) {
 		return nil, fmt.Errorf("failed to create config")
 	}
 
-	uiMgr := NewUIManager(cfg)
+	uiMgr := NewUIManager()
 
 	var proxyManager proxy.ProxyManager
 	if cfg.GetProxyMode() == config.ProxyModeL4 {
@@ -226,7 +226,7 @@ func (d *Daemon) run(ctx context.Context) error {
 			log.Printf("Failed to launch UI: %v", err)
 		}
 		if !proxy.ProxyCAInstalled() {
-			d.uiManager.StartSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
+			d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
 		}
 	}()
 
@@ -488,6 +488,17 @@ func (d *Daemon) heartbeat() error {
 		return nil
 	})
 	return nil
+}
+
+func (d *Daemon) showSetupWizard(steps []string) {
+	if len(steps) == 0 {
+		return
+	}
+	d.uiManager.StartSetupWizard(steps)
+	d.config.LastSetupWizardShownTime = time.Now()
+	if err := d.config.Save(); err != nil {
+		log.Printf("Failed to save config after showing setup wizard: %v", err)
+	}
 }
 
 func newSBOMRegistry() *sbom.Registry {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -228,7 +228,9 @@ func (d *Daemon) run(ctx context.Context) error {
 			log.Printf("Failed to launch UI: %v", err)
 		}
 
-		d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
+		if !proxy.ProxyCAInstalled() {
+			d.uiManager.StartSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
+		}
 	}()
 
 	// For restarts, make sure the proxy is started

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -227,9 +227,8 @@ func (d *Daemon) run(ctx context.Context) error {
 		if err := d.uiManager.Launch(ctx, d.ingress.Addr()); err != nil {
 			log.Printf("Failed to launch UI: %v", err)
 		}
-		if !proxy.ProxyCAInstalled() {
-			d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
-		}
+
+		d.showSetupWizard(ingress.ComputeSetupSteps(d.ctx, d.config))
 	}()
 
 	// For restarts, make sure the proxy is started

--- a/internal/daemon/ui_manager.go
+++ b/internal/daemon/ui_manager.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/AikidoSec/safechain-internals/internal/config"
 	"github.com/AikidoSec/safechain-internals/internal/platform"
 	"github.com/AikidoSec/safechain-internals/internal/uiclient"
 	"github.com/AikidoSec/safechain-internals/internal/utils"
@@ -22,6 +23,7 @@ const uiReadyTimeout = 5 * time.Second
 type UIManager struct {
 	Client  *uiclient.Client
 	process uiProcess
+	config  *config.ConfigInfo
 
 	launchMu    sync.Mutex
 	ctx         context.Context
@@ -32,9 +34,10 @@ type UIManager struct {
 	lastProxyStdoutMessage string
 }
 
-func NewUIManager() *UIManager {
+func NewUIManager(cfg *config.ConfigInfo) *UIManager {
 	return &UIManager{
 		Client: uiclient.New(),
+		config: cfg,
 	}
 }
 
@@ -181,6 +184,14 @@ func (m *UIManager) StartSetupWizard(steps []string) {
 	log.Printf("Starting setup wizard with steps: %v", steps)
 	if err := m.Client.StartSetupWizard(steps); err != nil {
 		log.Printf("Failed to start setup wizard: %v", err)
+		return
+	}
+
+	if m.config != nil {
+		m.config.LastSetupWizardShownTime = time.Now()
+		if err := m.config.Save(); err != nil {
+			log.Printf("Failed to save config after showing setup wizard: %v", err)
+		}
 	}
 }
 

--- a/internal/daemon/ui_manager.go
+++ b/internal/daemon/ui_manager.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AikidoSec/safechain-internals/internal/config"
 	"github.com/AikidoSec/safechain-internals/internal/platform"
 	"github.com/AikidoSec/safechain-internals/internal/uiclient"
 	"github.com/AikidoSec/safechain-internals/internal/utils"
@@ -23,7 +22,6 @@ const uiReadyTimeout = 5 * time.Second
 type UIManager struct {
 	Client  *uiclient.Client
 	process uiProcess
-	config  *config.ConfigInfo
 
 	launchMu    sync.Mutex
 	ctx         context.Context
@@ -34,10 +32,9 @@ type UIManager struct {
 	lastProxyStdoutMessage string
 }
 
-func NewUIManager(cfg *config.ConfigInfo) *UIManager {
+func NewUIManager() *UIManager {
 	return &UIManager{
 		Client: uiclient.New(),
-		config: cfg,
 	}
 }
 
@@ -184,14 +181,6 @@ func (m *UIManager) StartSetupWizard(steps []string) {
 	log.Printf("Starting setup wizard with steps: %v", steps)
 	if err := m.Client.StartSetupWizard(steps); err != nil {
 		log.Printf("Failed to start setup wizard: %v", err)
-		return
-	}
-
-	if m.config != nil {
-		m.config.LastSetupWizardShownTime = time.Now()
-		if err := m.config.Save(); err != nil {
-			log.Printf("Failed to save config after showing setup wizard: %v", err)
-		}
 	}
 }
 

--- a/internal/ingress/certificate.go
+++ b/internal/ingress/certificate.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -51,10 +52,11 @@ func (s *Server) handleCertificateInstall(w http.ResponseWriter, r *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := certconfig.Install(r.Context()); err != nil {
-		log.Printf("ingress: certconfig install: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	w.WriteHeader(http.StatusOK)
+
+	go func() {
+		if err := certconfig.Install(context.Background()); err != nil {
+			log.Printf("ingress: certconfig install: %v", err)
+		}
+	}()
 }


### PR DESCRIPTION
- Introduced LastSetupWizardShownTime to ConfigInfo to track when the setup wizard was last displayed.
- Added SetupWizardReshowInterval constant to manage the frequency of setup wizard prompts.
- Updated UIManager to save the timestamp when the setup wizard is initiated, ensuring proper state management.
- Refactored Daemon initialization to pass configuration to UIManager, enhancing dependency management.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added LastSetupWizardShownTime field and SetupWizardReshowInterval constant to ConfigInfo to track display time
* Ran certificate configuration installation asynchronously to avoid blocking responses

**🔧 Refactors**
* Refactored Daemon and UIManager initialization and introduced showSetupWizard method
* Standardized constants and ConfigInfo formatting without changing functional values


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107940268?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->