### PR TITLE
Replace OS notifications with tray-attached popup window

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -50,7 +50,7 @@ jobs:
       
       - name: Set up Wails (v3)
         run: |
-          go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.72
+          go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.78
           wails3 doctor  # Verify installation
 
       - name: Run tests

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Set up Wails (v3)
         run: |
-          go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.72
+          go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.78
           wails3 doctor  # Verify installation
 
       - name: Run tests

--- a/ui/daemonservice.go
+++ b/ui/daemonservice.go
@@ -112,3 +112,15 @@ func (s *DaemonService) CloseInstallWindow() {
 func (s *DaemonService) CollectLogs() error {
 	return daemon.CollectLogs()
 }
+
+func (s *DaemonService) OpenDashboardToEvent(eventId, eventType string) {
+	if openDashboardToEvent != nil {
+		openDashboardToEvent(eventId, eventType)
+	}
+}
+
+func (s *DaemonService) CloseTrayNotification() {
+	if closeTrayNotification != nil {
+		closeTrayNotification()
+	}
+}

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -1015,6 +1015,144 @@ body {
   line-height: 1.35;
 }
 
+/* --- Tray notification popup --------------------------------------------- */
+
+.tray-notif-root {
+  background: transparent;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  --wails-draggable: drag;
+}
+
+.tray-notif {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  padding: 14px 16px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow:
+    0 8px 30px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.08);
+  font-family: inherit;
+  overflow: hidden;
+}
+
+.tray-notif__empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.tray-notif__empty-text {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.tray-notif__logo {
+  height: 18px;
+  width: auto;
+}
+
+.tray-notif__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tray-notif__title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--primary-aik-140);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tray-notif__body {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--carbon-5);
+  border: 1px solid var(--carbon-20);
+  border-radius: 10px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.tray-notif__icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.tray-notif__info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
+}
+
+.tray-notif__package {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary-aik-140);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.tray-notif__footer {
+  margin-top: auto;
+  padding-top: 10px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.tray-notif__action {
+  border: none;
+  border-radius: 20px;
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+
+.tray-notif__action--primary {
+  background: var(--primary-aik-100);
+  color: #fff;
+}
+
+.tray-notif__action--primary:hover {
+  background: var(--primary-aik-120);
+}
+
+.tray-notif__action--dismiss {
+  background: transparent;
+  color: var(--text-muted);
+  outline: 1px solid var(--carbon-20);
+}
+
+.tray-notif__action--dismiss:hover {
+  background: var(--carbon-5);
+  color: var(--primary-aik-140);
+}
+
 /* --- Install (certificate) window ---------------------------------------- */
 
 .install-page {

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { TlsEventsList } from "./pages/TlsEventsList";
 import { TlsEventDetail } from "./pages/TlsEventDetail";
 import { ProtectedEcosystems } from "./pages/ProtectedEcosystems";
 import { InstallPage } from "./pages/InstallPage";
+import { TrayNotification } from "./pages/TrayNotification";
 import { getVersion, setupCheck, setupStart } from "./api";
 import logoUrl from "../assets/logo.svg";
 import "./App.css";
@@ -120,6 +121,7 @@ function App() {
     <HashRouter>
       <Routes>
         <Route path="/install" element={<InstallPage />} />
+        <Route path="/tray-notification" element={<TrayNotification />} />
         <Route element={<DashboardLayout />}>
           <Route path="/" element={<EventsList />} />
           <Route path="/events" element={<EventsList />} />

--- a/ui/frontend/src/api.ts
+++ b/ui/frontend/src/api.ts
@@ -90,3 +90,11 @@ export async function closeInstallWindow(): Promise<void> {
 export async function collectLogs(): Promise<void> {
   return DaemonService.CollectLogs();
 }
+
+export async function openDashboardToEvent(eventId: string, eventType: string): Promise<void> {
+  return DaemonService.OpenDashboardToEvent(eventId, eventType);
+}
+
+export async function closeTrayNotification(): Promise<void> {
+  return DaemonService.CloseTrayNotification();
+}

--- a/ui/frontend/src/pages/TrayNotification.tsx
+++ b/ui/frontend/src/pages/TrayNotification.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { Events } from "@wailsio/runtime";
+import type { BlockEvent } from "../types";
+import { BLOCK_REASON_LABEL, getToolIcon } from "../constants";
+import { openDashboardToEvent, closeTrayNotification } from "../api";
+import logoUrl from "../../assets/logo.svg";
+
+export function TrayNotification() {
+  const [event, setEvent] = useState<BlockEvent | null>(null);
+
+  useEffect(() => {
+    const unsub = Events.On("blocked", (ev: unknown) => {
+      const payload = (ev as { data?: BlockEvent }).data;
+      if (payload) setEvent(payload);
+    });
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  if (!event) {
+    return (
+      <div className="tray-notif-root">
+        <div className="tray-notif">
+          <div className="tray-notif__empty">
+            <img src={logoUrl} alt="Aikido" className="tray-notif__logo" />
+            <p className="tray-notif__empty-text">No recent events</p>
+            <button
+              type="button"
+              className="tray-notif__action tray-notif__action--dismiss"
+              onClick={() => {
+                closeTrayNotification();
+              }}
+            >
+              Close</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tray-notif-root">
+      <div className="tray-notif">
+        <div className="tray-notif__header">
+          <img src={logoUrl} alt="Aikido" className="tray-notif__logo" />
+          <span className="tray-notif__title">Event Blocked</span>
+        </div>
+        <div className="tray-notif__body">
+          <img
+            src={getToolIcon(event.artifact.product)}
+            alt={event.artifact.product}
+            className="tray-notif__icon"
+          />
+          <div className="tray-notif__info">
+            <span className="tray-notif__package">
+              {event.artifact.display_name || event.artifact.identifier}
+            </span>
+            <span className={`reason-badge reason-badge--${event.block_reason}`}>
+              {BLOCK_REASON_LABEL[event.block_reason] ?? event.block_reason}
+            </span>
+          </div>
+        </div>
+        <div className="tray-notif__footer">
+          <button
+            type="button"
+            className="tray-notif__action tray-notif__action--dismiss"
+            onClick={() => {
+              closeTrayNotification();
+            }}
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            className="tray-notif__action tray-notif__action--primary"
+            onClick={() => {
+              openDashboardToEvent(event.id, "block");
+            }}
+          >
+            Open Dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -2,7 +2,7 @@ module endpoint-protection-ui
 
 go 1.25
 
-require github.com/wailsapp/wails/v3 v3.0.0-alpha.72
+require github.com/wailsapp/wails/v3 v3.0.0-alpha.78
 
 require (
 	dario.cat/mergo v1.0.2 // indirect

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -109,8 +109,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+a0b9P0=
 github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
-github.com/wailsapp/wails/v3 v3.0.0-alpha.72 h1:1d2Y+/Ib7KdKHFnmZsKW/OAi66nyDZLmyv8AIKYk1yA=
-github.com/wailsapp/wails/v3 v3.0.0-alpha.72/go.mod h1:4saK4A4K9970X+X7RkMwP2lyGbLogcUz54wVeq4C/V8=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.78 h1:31nJb4N8X+SIBZ88RNkptFA1eUnBOH805tDV0sN7Vpk=
+github.com/wailsapp/wails/v3 v3.0.0-alpha.78/go.mod h1:4saK4A4K9970X+X7RkMwP2lyGbLogcUz54wVeq4C/V8=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/ui/main.go
+++ b/ui/main.go
@@ -32,6 +32,9 @@ type FocusEventPayload struct {
 var closeInstallWindow func()
 
 var setInstallWindowOnTop func(bool)
+var openDashboardToEvent func(eventId, eventType string)
+var closeTrayNotification func()
+var showTrayNotification func()
 
 type SetupStatePayload struct {
 	SetupRequired bool `json:"setupRequired"`
@@ -158,6 +161,7 @@ type windowManager struct {
 	app           *application.App
 	window        *application.WebviewWindow
 	installWindow *application.WebviewWindow
+	notifWindow   *application.WebviewWindow
 	installMu     sync.Mutex
 }
 
@@ -181,10 +185,31 @@ func installWindowOpts() application.WebviewWindowOptions {
 	}
 }
 
+func trayNotifWindowOpts() application.WebviewWindowOptions {
+	return application.WebviewWindowOptions{
+		Name:           "tray-notification",
+		Width:          360,
+		Height:         160,
+		Hidden:         true,
+		Frameless:      true,
+		DisableResize:  true,
+		AlwaysOnTop:    true,
+		URL:            "/#/tray-notification",
+		BackgroundType: application.BackgroundTypeTransparent,
+		Windows: application.WindowsWindow{
+			HiddenOnTaskbar: true,
+		},
+		Mac: application.MacWindow{
+			CollectionBehavior: application.MacWindowCollectionBehaviorMoveToActiveSpace,
+		},
+	}
+}
+
 func newWindowManager(app *application.App) *windowManager {
 	wm := &windowManager{app: app}
 	wm.window = app.Window.NewWithOptions(mainWindowOpts())
 	wm.installWindow = app.Window.NewWithOptions(installWindowOpts())
+	wm.notifWindow = app.Window.NewWithOptions(trayNotifWindowOpts())
 	wm.interceptClose(wm.window)
 	wm.interceptClose(wm.installWindow)
 	closeInstallWindow = func() {
@@ -267,7 +292,7 @@ func wrapText(text string, maxWidth int) []string {
 
 const maxStatusLines = 4
 
-func setupSystemTray(app *application.App, showDashboard func()) chan<- appserver.ProxyStatusBody {
+func setupSystemTray(app *application.App, showDashboard func(), notifWindow *application.WebviewWindow) chan<- appserver.ProxyStatusBody {
 	systray := app.SystemTray.New()
 	systray.SetTooltip("Aikido Endpoint Protection")
 	if runtime.GOOS == "darwin" {
@@ -275,6 +300,7 @@ func setupSystemTray(app *application.App, showDashboard func()) chan<- appserve
 	} else {
 		systray.SetIcon(icon)
 	}
+	systray.AttachWindow(notifWindow)
 
 	menu := application.NewMenu()
 	statusLines := make([]*application.MenuItem, maxStatusLines)
@@ -301,8 +327,23 @@ func setupSystemTray(app *application.App, showDashboard func()) chan<- appserve
 		showDashboard()
 	})
 	systray.SetMenu(menu)
-	if runtime.GOOS == "windows" {
-		systray.OnClick(systray.OpenMenu)
+
+	hideNotifAndOpenMenu := func() {
+		if notifWindow.IsVisible() {
+			notifWindow.Hide()
+		}
+		systray.OpenMenu()
+	}
+	systray.OnClick(hideNotifAndOpenMenu)
+	systray.OnRightClick(hideNotifAndOpenMenu)
+
+	showTrayNotification = func() {
+		if notifWindow.IsVisible() {
+			return
+		}
+		systray.PositionWindow(notifWindow, 2)
+		systray.WindowDebounce(200 * time.Millisecond)
+		notifWindow.Show()
 	}
 
 	var setupHidden atomic.Bool
@@ -361,6 +402,8 @@ func handleBlockedEventCreated(app *application.App, notifier *notifications.Not
 			CategoryID: "aikido-blocked",
 			Data:       map[string]interface{}{"eventId": ev.ID, "eventType": "block"},
 		})
+	} else if showTrayNotification != nil {
+		showTrayNotification()
 	}
 }
 
@@ -404,8 +447,24 @@ func main() {
 
 	wm := newWindowManager(app)
 
-	statusCh := setupSystemTray(app, wm.showDashboard)
+	statusCh := setupSystemTray(app, wm.showDashboard, wm.notifWindow)
 	startAppServer(app, wm, statusCh, notifier)
+
+	openDashboardToEvent = func(eventId, eventType string) {
+		if wm.notifWindow != nil {
+			wm.notifWindow.Hide()
+		}
+		wm.showDashboard()
+		go func() {
+			app.Event.Emit("focus_event", FocusEventPayload{EventId: eventId, EventType: eventType})
+		}()
+	}
+
+	closeTrayNotification = func() {
+		if wm.notifWindow != nil {
+			wm.notifWindow.Hide()
+		}
+	}
 
 	// On macOS, clicking the app bundle while running triggers a default Wails
 	// listener that shows ALL hidden windows. Register a hook (runs before

--- a/ui/mock/main.go
+++ b/ui/mock/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -187,14 +188,14 @@ func seedPermissions() PermissionsResponse {
 // ── server ───────────────────────────────────────────────────────────
 
 type server struct {
-	mu                   sync.RWMutex
-	blocks               []BlockEvent
-	tlsEvents            []TlsEvent
-	permissions          PermissionsResponse
-	extensionInstalled   bool
-	extensionActivated   bool
-	vpnAllowed           bool
-	token                string
+	mu                 sync.RWMutex
+	blocks             []BlockEvent
+	tlsEvents          []TlsEvent
+	permissions        PermissionsResponse
+	extensionInstalled bool
+	extensionActivated bool
+	vpnAllowed         bool
+	token              string
 }
 
 func (s *server) writeJSON(w http.ResponseWriter, v any) {
@@ -389,6 +390,62 @@ func (s *server) handleSetupRestart(w http.ResponseWriter, r *http.Request) {
 	s.writeJSON(w, map[string]string{"status": "restarting"})
 }
 
+var mockBlocks = []BlockEvent{
+	{
+		Artifact:    Artifact{Product: "npm", Identifier: "evil-pkg", Version: "1.0.0", DisplayName: "evil-pkg"},
+		BlockReason: "malware",
+		Status:      "blocked",
+		Count:       1,
+	},
+	{
+		Artifact:    Artifact{Product: "pypi", Identifier: "shady-lib", Version: "0.3.1", DisplayName: "shady-lib"},
+		BlockReason: "rejected",
+		Status:      "blocked",
+		Count:       1,
+	},
+	{
+		Artifact:    Artifact{Product: "chrome", Identifier: "abc123extensionid", Version: "2.0.0", DisplayName: "Suspicious Extension"},
+		BlockReason: "block_all",
+		Status:      "blocked",
+		Count:       1,
+	},
+	{
+		Artifact:    Artifact{Product: "maven", Identifier: "log4shell-fork", Version: "3.0.0", DisplayName: "log4shell-fork"},
+		BlockReason: "new_package",
+		Status:      "blocked",
+		Count:       1,
+	},
+}
+
+func simulateBlockEvents(uiAddr, token string) {
+	time.Sleep(5 * time.Second)
+	i := 0
+	for {
+		ev := mockBlocks[i%len(mockBlocks)]
+		ev.ID = fmt.Sprintf("sim-%d", time.Now().UnixMilli())
+		ev.TsMs = time.Now().UnixMilli()
+
+		body, _ := json.Marshal(ev)
+		req, err := http.NewRequest("POST", uiAddr+"/v1/blocked", bytes.NewReader(body))
+		if err != nil {
+			log.Printf("mock: simulate block: %v", err)
+		} else {
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				log.Printf("mock: simulate block POST failed: %v", err)
+			} else {
+				resp.Body.Close()
+				log.Printf("mock: simulated block event %s (%s)", ev.Artifact.DisplayName, ev.ID)
+			}
+		}
+
+		i++
+		time.Sleep(10 * time.Second)
+	}
+}
+
 func main() {
 	blocks, tlsEvents := seedData()
 	s := &server{blocks: blocks, tlsEvents: tlsEvents, permissions: seedPermissions()}
@@ -417,6 +474,10 @@ func main() {
 	mux.HandleFunc("GET /v1/setup/check", s.handleSetupCheck)
 	mux.HandleFunc("POST /v1/setup/start", s.handleSetupStart)
 	mux.HandleFunc("POST /v1/setup/restart", s.handleSetupRestart)
+
+	uiAddr := "http://127.0.0.1:9876"
+	token := "devtoken"
+	go simulateBlockEvents(uiAddr, token)
 
 	addr := "127.0.0.1:7878"
 	fmt.Printf("Mock daemon listening on %s\n", addr)


### PR DESCRIPTION
<img width="397" height="210" alt="image" src="https://github.com/user-attachments/assets/a341da92-ffb1-4c22-994b-47b8bee5c3a6" />

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Replaced OS notifications with tray-attached popup window implementation.
* Added frontend TrayNotification component and registered corresponding route.

**⚡ Enhancements**
* Exposed OpenDashboardToEvent and CloseTrayNotification via daemon service.
* Added JS API bindings for opening dashboard and closing tray notification.
* Upgraded Wails installer version in CI workflows to alpha.78.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107535741?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->