### PR TITLE
filter out tailscale control-plane/log ip ranges

### DIFF
--- a/proxy-lib-nostd/src/net/ip.rs
+++ b/proxy-lib-nostd/src/net/ip.rs
@@ -8,6 +8,7 @@
 //! References:
 //! - <https://www.iana.org/assignments/iana-ipv4-special-registry/>
 //! - <https://www.iana.org/assignments/iana-ipv6-special-registry/>
+//! - <https://tailscale.com/kb/1082/firewall-ports> (Tailscale DERP + log infra ranges)
 
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -40,6 +41,7 @@ pub fn is_passthrough_ipv4(addr: Ipv4Addr) -> bool {
         || is_ipv4_protocol_assignments(val)
         || is_ipv4_benchmarking(val)
         || is_ipv4_reserved(val)
+        || is_ipv4_tailscale_infra(val)
 }
 
 /// Returns `true` for IPv6 ranges that are not meant to be treated as ordinary
@@ -60,6 +62,7 @@ pub fn is_passthrough_ipv6(addr: Ipv6Addr) -> bool {
         || is_ipv6_discard_only(val)
         || is_ipv6_dummy_prefix(val)
         || is_ipv6_local_use_translation(val)
+        || is_ipv6_tailscale_infra(val)
 }
 
 // --- IPv4 Helpers ---
@@ -101,6 +104,18 @@ fn is_ipv4_reserved(val: u32) -> bool {
     val & 0xF000_0000 == 0xF000_0000
 }
 
+#[inline(always)]
+fn is_ipv4_tailscale_infra(val: u32) -> bool {
+    // Tailscale DERP relay servers: 192.200.0.0/24
+    // Tailscale log infrastructure (log.tailscale.com): 199.165.136.0/24
+    // Both ranges are statically registered to Tailscale and used as DERP relay
+    // and control-plane endpoints. Intercepting them delays WireGuard tunnel
+    // recovery without any security benefit.
+    // Ref: <https://tailscale.com/kb/1082/firewall-ports>
+    (val & 0xFFFF_FF00 == 0xC0C8_0000)  // 192.200.0.0/24
+        || (val & 0xFFFF_FF00 == 0xC7A5_8800) // 199.165.136.0/24
+}
+
 // --- IPv6 Helpers ---
 
 #[inline(always)]
@@ -137,6 +152,16 @@ fn is_ipv6_dummy_prefix(val: u128) -> bool {
 fn is_ipv6_local_use_translation(val: u128) -> bool {
     // RFC 8215 local-use translation prefix: 64:ff9b:1::/48.
     (val >> 80) == 0x0064_ff9b_0001
+}
+
+#[inline(always)]
+fn is_ipv6_tailscale_infra(val: u128) -> bool {
+    // Tailscale DERP relay servers: 2606:B740:49::/48
+    // Tailscale log infrastructure (log.tailscale.com): 2606:B740:1::/48
+    // IPv6 counterparts to the Tailscale-registered IPv4 DERP and log ranges.
+    // Ref: <https://tailscale.com/kb/1082/firewall-ports>
+    (val >> 80) == 0x2606_B740_0049  // 2606:B740:49::/48
+        || (val >> 80) == 0x2606_B740_0001 // 2606:B740:1::/48
 }
 
 #[cfg(test)]

--- a/proxy-lib-nostd/src/net/ip_tests.rs
+++ b/proxy-lib-nostd/src/net/ip_tests.rs
@@ -188,3 +188,54 @@ fn test_trait_dispatch_consistency() {
     assert!(is_passthrough_ip([127, 0, 0, 1]));
     assert!(!is_passthrough_ip([8, 8, 8, 8]));
 }
+
+#[test]
+fn passthrough_tailscale_infra_ranges() {
+    // Tailscale DERP relay: 192.200.0.0/24
+    // Tailscale log infra: 199.165.136.0/24
+    // Ref: https://tailscale.com/kb/1082/firewall-ports
+    let ipv4_cases = [
+        // 192.200.0.0/24 — DERP relay servers
+        (Ipv4Addr::new(192, 200, 0, 0), true),
+        (Ipv4Addr::new(192, 200, 0, 1), true),
+        (Ipv4Addr::new(192, 200, 0, 255), true),
+        // just outside
+        (Ipv4Addr::new(192, 199, 255, 255), false),
+        (Ipv4Addr::new(192, 201, 0, 0), false),
+        // 199.165.136.0/24 — log.tailscale.com
+        (Ipv4Addr::new(199, 165, 136, 0), true),
+        (Ipv4Addr::new(199, 165, 136, 100), true),
+        (Ipv4Addr::new(199, 165, 136, 255), true),
+        // just outside
+        (Ipv4Addr::new(199, 165, 135, 255), false),
+        (Ipv4Addr::new(199, 165, 137, 0), false),
+    ];
+
+    for (addr, expected) in ipv4_cases {
+        assert_eq!(is_passthrough_ipv4(addr), expected, "addr: {addr}");
+    }
+
+    // Tailscale DERP relay: 2606:B740:49::/48
+    // Tailscale log infra: 2606:B740:1::/48
+    let ipv6_cases: &[(&str, bool)] = &[
+        // 2606:B740:49::/48 — DERP relay servers
+        ("2606:b740:49::", true),
+        ("2606:b740:49::1", true),
+        ("2606:b740:49:ffff:ffff:ffff:ffff:ffff", true),
+        // just outside
+        ("2606:b740:48:ffff::1", false),
+        ("2606:b740:4a::1", false),
+        // 2606:B740:1::/48 — log.tailscale.com
+        ("2606:b740:1::", true),
+        ("2606:b740:1::1", true),
+        ("2606:b740:1:ffff:ffff:ffff:ffff:ffff", true),
+        // just outside
+        ("2606:b740:0:ffff::1", false),
+        ("2606:b740:2::1", false),
+    ];
+
+    for (addr_str, expected) in ipv6_cases {
+        let addr: Ipv6Addr = addr_str.parse().unwrap();
+        assert_eq!(is_passthrough_ipv6(addr), *expected, "addr: {addr_str}");
+    }
+}


### PR DESCRIPTION
in an ideal world shouldn't be needed, but if this works, we can look for alternative solutions later...

as ip ranges can change, so this is not a super ideal solution

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Filtered out Tailscale control-plane and log IP ranges in checks

**📚 Documentation**
* Added Tailscale firewall KB reference link to module comments


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108002879?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->