### PR TITLE
Patch/smarter peek durations

### DIFF
--- a/proxy-bin-l4/src/main.rs
+++ b/proxy-bin-l4/src/main.rs
@@ -111,7 +111,7 @@ pub struct Args {
     pub aikido_url: Uri,
 
     /// Peek duration in seconds (fractional).
-    #[arg(long, default_value_t = 0.5)]
+    #[arg(long, default_value_t = 0.2)]
     pub peek_duration: f64,
 
     #[cfg(target_family = "unix")]
@@ -166,7 +166,7 @@ async fn run_with_args(args: Args) -> Result<(), BoxError> {
     let graceful = graceful::Shutdown::default();
 
     let agent_identity = AgentIdentity::load(&args.data);
-    let peek_duration = Duration::from_secs_f64(args.peek_duration.max(0.05));
+    let peek_duration = Duration::from_secs_f64(args.peek_duration.max(0.001));
 
     let maybe_tcp_server_addr_v6 = if let Some(bind_ipv6) = args.bind_ipv6 {
         Some(

--- a/proxy-lib-l4-macos/src/config.rs
+++ b/proxy-lib-l4-macos/src/config.rs
@@ -17,13 +17,21 @@ use serde::{Deserialize, Deserializer};
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct ProxyConfig {
-    /// Duration in seconds to peek into a connection before deciding how to handle it.
+    /// Duration in seconds to peek into a connection on known ports,
+    /// where we have a high chance it might contain relevant data.
     ///
-    /// This is typically used during protocol detection or early inspection
-    /// of incoming traffic.
+    /// The minimum accepted value is 1 ms; anything lower is clamped up.
     ///
-    /// Defaults to `0.5`.
+    /// Defaults to `0.2`.
     pub peek_duration_s: f64,
+
+    /// Duration in seconds to peek into a connection on unknown ports.
+    ///
+    /// These flows are less likely to carry relevant data flows, so a shorter window wastes
+    /// less time when no relevant data arrives. Floor of 1ms.
+    ///
+    /// Defaults to `0.01`.
+    pub peek_unknown_port_duration_s: f64,
 
     /// Optional identity of the running agent.
     ///
@@ -58,7 +66,8 @@ pub struct ProxyConfig {
 impl Default for ProxyConfig {
     fn default() -> Self {
         Self {
-            peek_duration_s: 0.5,
+            peek_duration_s: 0.2,
+            peek_unknown_port_duration_s: 0.01,
             agent_identity: None,
             reporting_endpoint: None,
             aikido_url: Uri::from_static("https://app.aikido.dev"),

--- a/proxy-lib-l4-macos/src/config_tests.rs
+++ b/proxy-lib-l4-macos/src/config_tests.rs
@@ -31,6 +31,7 @@ fn deserializes_valid_configs() {
             Some(
                 br#"{
                         "peek_duration_s": 12.5,
+                        "peek_unknown_port_duration_s": 0.03,
                         "reporting_endpoint": "https://collector.aikido.dev/report",
                         "aikido_url": "https://app.aikido.dev",
                         "ca_cert_pem": "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n",
@@ -39,6 +40,7 @@ fn deserializes_valid_configs() {
             ),
             ProxyConfig {
                 peek_duration_s: 12.5,
+                peek_unknown_port_duration_s: 0.03,
                 reporting_endpoint: Some(Uri::from_static("https://collector.aikido.dev/report")),
                 aikido_url: Uri::from_static("https://app.aikido.dev"),
                 ca_cert_pem: Some(

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -148,6 +148,8 @@ impl TcpMitmService {
         &self,
         exec: Executor,
         within_connect_tunnel: bool,
+        tls_peek_duration: Duration,
+        http_peek_duration: Duration,
     ) -> impl Service<BridgeIo<Ingress, Egress>, Output = (), Error = Infallible> + Clone
     where
         Ingress: Io + Unpin + ExtensionsRef,
@@ -161,10 +163,13 @@ impl TcpMitmService {
             self.firewall.clone(),
             self.ca_crt_pem_bytes,
             within_connect_tunnel,
+            tls_peek_duration,
+            http_peek_duration,
         )
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn new_tcp_service_inner<Issuer, Ingress, Egress>(
     exec: Executor,
     proxy_config: ProxyConfig,
@@ -173,14 +178,14 @@ fn new_tcp_service_inner<Issuer, Ingress, Egress>(
     firewall: Firewall,
     ca_crt_pem_bytes: &'static [u8],
     within_connect_tunnel: bool,
+    tls_peek_duration: Duration,
+    http_peek_duration: Duration,
 ) -> impl Service<BridgeIo<Ingress, Egress>, Output = (), Error = Infallible> + Clone
 where
     Issuer: BoringMitmCertIssuer<Error: Into<BoxError>> + Clone,
     Ingress: Io + Unpin + ExtensionsRef,
     Egress: Io + Unpin + ExtensionsRef,
 {
-    let peek_duration = Duration::from_secs_f64(proxy_config.peek_duration_s.max(0.05));
-
     let http_mitm_svc =
         HttpMitmRelay::new(exec.clone()).with_http_middleware(http_relay_middleware(
             exec,
@@ -190,16 +195,18 @@ where
             firewall,
             ca_crt_pem_bytes,
             within_connect_tunnel,
+            tls_peek_duration,
+            http_peek_duration,
         ));
 
     let maybe_http_mitm_svc = HttpPeekRouter::new(http_mitm_svc)
-        .with_peek_timeout(peek_duration)
+        .with_peek_timeout(http_peek_duration)
         .with_fallback(IoForwardService::new());
 
     let app_mitm_layer = PeekTlsClientHelloService::new(
         (tls_mitm_relay_policy, tls_mitm_relay).into_layer(maybe_http_mitm_svc.clone()),
     )
-    .with_peek_timeout(peek_duration)
+    .with_peek_timeout(tls_peek_duration)
     .with_fallback(maybe_http_mitm_svc);
 
     if within_connect_tunnel {
@@ -208,12 +215,13 @@ where
 
     let socks5_mitm_relay = Socks5MitmRelayService::new(app_mitm_layer.clone());
     let mitm_svc = Socks5PeekRouter::new(socks5_mitm_relay)
-        .with_peek_timeout(peek_duration)
+        .with_peek_timeout(http_peek_duration)
         .with_fallback(app_mitm_layer);
 
     Either::B(ConsumeErrLayer::trace_as_debug().into_layer(mitm_svc))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn http_relay_middleware<S, Issuer>(
     exec: Executor,
     proxy_config: ProxyConfig,
@@ -222,6 +230,8 @@ fn http_relay_middleware<S, Issuer>(
     firewall: Firewall,
     ca_crt_pem_bytes: &'static [u8],
     within_connect_tunnel: bool,
+    tls_peek_duration: Duration,
+    http_peek_duration: Duration,
 ) -> impl Layer<S, Service: Service<Request, Output = Response, Error = BoxError> + Clone>
 + Send
 + Sync
@@ -244,6 +254,8 @@ where
             firewall.clone(),
             ca_crt_pem_bytes,
             true,
+            tls_peek_duration,
+            http_peek_duration,
         )
         .boxed()
     };
@@ -355,8 +367,41 @@ impl Service<TcpFlow> for TcpInterceptService {
                 }
             };
 
-        let mitm_svc = self.mitm.new_bridge_service(self.exec.clone(), false);
+        let cfg = &self.mitm.proxy_config;
+        let port = egress_addr.port;
+        let tls_peek_duration = Duration::from_secs_f64(
+            if is_known_tls_port(port) {
+                cfg.peek_duration_s
+            } else {
+                cfg.peek_unknown_port_duration_s
+            }
+            .max(0.001),
+        );
+        let http_peek_duration = Duration::from_secs_f64(
+            if is_known_http_port(port) {
+                cfg.peek_duration_s
+            } else {
+                cfg.peek_unknown_port_duration_s
+            }
+            .max(0.001),
+        );
+        let mitm_svc = self.mitm.new_bridge_service(
+            self.exec.clone(),
+            false,
+            tls_peek_duration,
+            http_peek_duration,
+        );
         let _ = mitm_svc.serve(BridgeIo(ingress, egress)).await;
         Ok(())
     }
+}
+
+#[inline]
+fn is_known_tls_port(port: u16) -> bool {
+    matches!(port, 443 | 8443)
+}
+
+#[inline]
+fn is_known_http_port(port: u16) -> bool {
+    matches!(port, 80 | 443 | 8080 | 8443)
 }

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -53,7 +53,7 @@ use safechain_proxy_lib::{
         ws_relay::WebSocketMitmRelayService,
     },
     storage,
-    tcp::new_tcp_connector_service_for_proxy,
+    tcp::{is_known_http_port, is_known_tls_port, new_tcp_connector_service_for_proxy},
     tls::{RootCaKeyPair, mitm_relay_policy::TlsMitmRelayPolicyLayer},
     utils::token::AgentIdentity,
 };
@@ -394,14 +394,4 @@ impl Service<TcpFlow> for TcpInterceptService {
         let _ = mitm_svc.serve(BridgeIo(ingress, egress)).await;
         Ok(())
     }
-}
-
-#[inline]
-fn is_known_tls_port(port: u16) -> bool {
-    matches!(port, 443 | 8443)
-}
-
-#[inline]
-fn is_known_http_port(port: u16) -> bool {
-    matches!(port, 80 | 443 | 8080 | 8443)
 }

--- a/proxy-lib/src/tcp/mod.rs
+++ b/proxy-lib/src/tcp/mod.rs
@@ -2,3 +2,24 @@ mod connector;
 pub use self::connector::{
     new_tcp_connector_service_for_internal, new_tcp_connector_service_for_proxy,
 };
+
+/// Returns `true` for ports where TLS traffic is commonly expected (443, 8443).
+///
+/// Used to select a longer peek window for `PeekTlsClientHelloService` only
+/// on ports where a TLS ClientHello is actually likely to arrive.
+#[inline]
+#[must_use]
+pub fn is_known_tls_port(port: u16) -> bool {
+    matches!(port, 443 | 8443)
+}
+
+/// Returns `true` for ports where HTTP or HTTPS traffic is commonly expected
+/// (80, 443, 8080, 8443).
+///
+/// Used to select a longer peek window for `HttpPeekRouter` on ports where
+/// an HTTP request is likely to arrive.
+#[inline]
+#[must_use]
+pub fn is_known_http_port(port: u16) -> bool {
+    matches!(port, 80 | 443 | 8080 | 8443)
+}


### PR DESCRIPTION
For macos l4 proxy, an attempt in a small optimization. Don't think it will do much if anything at all,
but in some cases it might cause speedups for some background protocols.

Only peek http/tls with a slightly longer peek windows if it's a known std port for that protocol,
and otherwise use a shorter window.

Mostly just an experiment, don't think it will be a noticable change,
but never the less a good chance probably anyway. As I noticed some protocols in logs of Samuel
from background services (e.g. from apple) which are "server first" protocols,
meaning there would be nothing to peek for those... so at least those will have now only a very short window to peek.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Introduced port-aware peek durations; added config, CLI, and tests.
* Added helper functions is_known_http_port and is_known_tls_port for selecting longer peek windows.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108313472?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->