### PR TITLE
Use /gz/npm.json for an e2e test

### DIFF
--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -77,7 +77,7 @@ impl RuleNpm {
 
         let remote_released_packages_list = RemoteReleasedPackagesList::try_new(
             guard.clone(),
-            Uri::from_static("https://malware-list.aikido.dev/releases/npm.json"),
+            Uri::from_static("https://malware-list.aikido.dev/releases/gz/npm.json"),
             sync_storage,
             remote_malware_list_https_client,
         )


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added compressed npm releases file at /gz/npm.json to repository

**⚡ Enhancements**
* Updated npm remote releases URI to use /gz/npm.json


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108689190?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->