### PR TITLE
Add refresh config url

### DIFF
--- a/proxy-bin-l4/src/tcp/mod.rs
+++ b/proxy-bin-l4/src/tcp/mod.rs
@@ -281,7 +281,7 @@ where
         StreamCompressionLayer::new().with_compress_predicate(MirrorDecompressed::new()),
         HijackLayer::new(
             DomainMatcher::exact(HIJACK_DOMAIN),
-            Arc::new(hijack::new_service(ca_crt_pem_bytes)),
+            Arc::new(hijack::new_service(ca_crt_pem_bytes, firewall.clone())),
         ),
         firewall,
         MapResponseBodyLayer::new_boxed_streaming_body(),

--- a/proxy-bin-l7/src/server/proxy/server.rs
+++ b/proxy-bin-l7/src/server/proxy/server.rs
@@ -128,7 +128,7 @@ where
         ),
         HijackLayer::new(
             DomainMatcher::exact(HIJACK_DOMAIN),
-            Arc::new(hijack::new_service(ca_crt_pem_bytes)),
+            Arc::new(hijack::new_service(ca_crt_pem_bytes, firewall.clone())),
         ),
         firewall,
         MapResponseBodyLayer::new_boxed_streaming_body(),

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -253,7 +253,7 @@ where
         StreamCompressionLayer::new().with_compress_predicate(MirrorDecompressed::new()),
         HijackLayer::new(
             DomainMatcher::exact(HIJACK_DOMAIN),
-            Arc::new(hijack::new_service(ca_crt_pem_bytes)),
+            Arc::new(hijack::new_service(ca_crt_pem_bytes, firewall.clone())),
         ),
         firewall,
         MapResponseBodyLayer::new_boxed_streaming_body(),

--- a/proxy-lib/src/endpoint_protection/remote_app_passthrough_list/mod.rs
+++ b/proxy-lib/src/endpoint_protection/remote_app_passthrough_list/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     http::firewall::domain_matcher::DomainMatcher,
     storage::SyncCompactDataStorage,
-    utils::remote_resource::{self, RemoteResource, RemoteResourceSpec},
+    utils::remote_resource::{self, RefreshHandle, RemoteResource, RemoteResourceSpec},
     utils::token::AgentIdentity,
 };
 
@@ -25,6 +25,7 @@ pub struct PassthroughMatchContext<'a> {
 #[derive(Debug, Clone)]
 pub struct RemoteAppPassthroughList {
     list: RemoteResource<Option<PassthroughList>>,
+    refresh_handle: RefreshHandle,
 }
 
 impl RemoteAppPassthroughList {
@@ -44,11 +45,18 @@ impl RemoteAppPassthroughList {
             uri,
         });
 
-        let (list, _refresh_handle) = remote_resource::try_new(guard, data, client, spec)
+        let (list, refresh_handle) = remote_resource::try_new(guard, data, client, spec)
             .await
             .context("create new remote app passthrough list")?;
 
-        Ok(Self { list })
+        Ok(Self {
+            list,
+            refresh_handle,
+        })
+    }
+
+    pub fn trigger_refresh(&self) {
+        self.refresh_handle.trigger_refresh();
     }
 
     pub fn is_source_app_passthrough(&self, passthrough_context: &PassthroughMatchContext) -> bool {

--- a/proxy-lib/src/http/firewall/mod.rs
+++ b/proxy-lib/src/http/firewall/mod.rs
@@ -69,6 +69,8 @@ pub struct Firewall {
     block_rules: Arc<[self::rule::DynRule]>,
     notifier: Option<self::notifier::EventNotifier>,
     passthrough_list: Option<RemoteAppPassthroughList>,
+    agent_identity: Option<AgentIdentity>,
+    remote_endpoint_config: Option<RemoteEndpointConfig>,
 }
 
 pub struct IncomingFlowInfo<'a> {
@@ -126,6 +128,7 @@ impl Firewall {
             None => None,
         };
 
+        let stored_agent_identity = agent_identity.clone();
         let passthrough_list = match agent_identity {
             Some(identity) => {
                 match RemoteAppPassthroughList::try_new(
@@ -149,6 +152,8 @@ impl Firewall {
             }
             None => None,
         };
+
+        let stored_endpoint_config = remote_endpoint_config.clone();
 
         Ok(Self {
             block_rules: Arc::from([
@@ -234,6 +239,8 @@ impl Firewall {
             ]),
             notifier,
             passthrough_list,
+            agent_identity: stored_agent_identity,
+            remote_endpoint_config: stored_endpoint_config,
         })
     }
 
@@ -333,6 +340,22 @@ impl Firewall {
         };
 
         passthrough_list.is_source_app_passthrough(passthrough_context)
+    }
+
+    pub fn is_agent_authorized(&self, req: &Request) -> bool {
+        match &self.agent_identity {
+            Some(identity) => identity.is_authorized(req),
+            None => false,
+        }
+    }
+
+    pub fn trigger_refresh_all(&self) {
+        if let Some(config) = &self.remote_endpoint_config {
+            config.trigger_refresh();
+        }
+        if let Some(list) = &self.passthrough_list {
+            list.trigger_refresh();
+        }
     }
 }
 

--- a/proxy-lib/src/http/service/hijack.rs
+++ b/proxy-lib/src/http/service/hijack.rs
@@ -13,6 +13,8 @@ use rama::{
     net::address::Domain,
 };
 
+use crate::http::firewall::Firewall;
+
 /// The proxy exposes a special “hijack domain” that is intercepted and
 /// handled locally by the proxy itself, rather than being resolved externally.
 /// The hijack service provides the following resources:
@@ -38,6 +40,7 @@ pub const HIJACK_DOMAIN: Domain = Domain::from_static("mitm.ramaproxy.org");
 
 pub fn new_service(
     root_ca_pem: &'static [u8],
+    firewall: Firewall,
 ) -> impl Service<Request, Output = Response, Error = Infallible> {
     Router::new()
         .with_get("/", Html(STATIC_INDEX_PAGE))
@@ -49,6 +52,13 @@ pub fn new_service(
                 HeaderValue::from_static("application/x-pem-file"),
             );
             std::future::ready(resp)
+        })
+        .with_post("/config/refresh", move |req: Request| {
+            if !firewall.is_agent_authorized(&req) {
+                return std::future::ready(StatusCode::UNAUTHORIZED.into_response());
+            }
+            firewall.trigger_refresh_all();
+            std::future::ready(StatusCode::NO_CONTENT.into_response())
         })
 }
 

--- a/proxy-lib/src/utils/token/mod.rs
+++ b/proxy-lib/src/utils/token/mod.rs
@@ -26,6 +26,13 @@ impl std::fmt::Debug for AgentIdentity {
 }
 
 impl AgentIdentity {
+    pub fn is_authorized<B>(&self, req: &Request<B>) -> bool {
+        req.headers()
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            == Some(self.token.as_ref())
+    }
+
     pub fn add_request_headers<B>(&self, req: &mut Request<B>) -> Result<(), BoxError> {
         req.headers_mut().insert(
             AUTHORIZATION,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added hijack HTTP endpoint to trigger config refresh remotely.
* Required agent authorization and added AgentIdentity.is_authorized check.
* Made remote app passthrough list refreshable via RefreshHandle and trigger.

**🔧 Refactors**
* Consolidated multiple peek timeout parameters into single peek_duration.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108968266?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->