### PR TITLE
MacOS L4 - Add --no-firewall startup option

### DIFF
--- a/packaging/macos/xcode/l4-proxy/Host/main.swift
+++ b/packaging/macos/xcode/l4-proxy/Host/main.swift
@@ -1124,7 +1124,7 @@ private final class TransparentProxyHostCLI {
           --clean-secrets            Delete proxy CA secrets before starting to rotate the MITM CA.
           --reset-profile            Remove the saved Network Extension profile before starting.
           --help                     Show this help text.
-          --no-firwall               Don't setup the firewall
+          --no-firewall               Don't setup the firewall
 
         Notes:
           - The transparent proxy extension is managed by macOS after `start`; this host process

--- a/packaging/macos/xcode/l4-proxy/Host/main.swift
+++ b/packaging/macos/xcode/l4-proxy/Host/main.swift
@@ -34,6 +34,7 @@ private struct StartOptions {
     var agentDeviceID: String?
     var resetProfile = false
     var cleanSecrets = false
+    var noFirewall = false
 }
 
 private struct AgentIdentityPayload: Encodable, Equatable {
@@ -53,6 +54,7 @@ private struct ProxyEngineConfigPayload: Encodable, Equatable {
     let hostBundleID: String
     let caCertPEM: String?
     let caKeyPEM: String?
+    let noFirewall: Bool
 
     private enum CodingKeys: String, CodingKey {
         case agentIdentity = "agent_identity"
@@ -61,6 +63,7 @@ private struct ProxyEngineConfigPayload: Encodable, Equatable {
         case hostBundleID = "host_bundle_id"
         case caCertPEM = "ca_cert_pem"
         case caKeyPEM = "ca_key_pem"
+        case noFirewall = "no_firewall"
     }
 
     var isEmpty: Bool {
@@ -766,6 +769,8 @@ private final class TransparentProxyHostCLI {
                 options.resetProfile = true
             case "--clean-secrets":
                 options.cleanSecrets = true
+            case "--no-firewall":
+                options.noFirewall = true
             default:
                 throw CLIError.usage("unknown `start` argument: \(argument)")
             }
@@ -851,7 +856,8 @@ private final class TransparentProxyHostCLI {
             aikidoURL: options.aikidoURL,
             hostBundleID: Bundle.main.bundleIdentifier ?? "com.aikido.endpoint.proxy.l4.dev",
             caCertPEM: ca.certPEM,
-            caKeyPEM: ca.keyPEM
+            caKeyPEM: ca.keyPEM,
+            noFirewall: options.noFirewall
         )
 
         let encoder = JSONEncoder()
@@ -1118,6 +1124,7 @@ private final class TransparentProxyHostCLI {
           --clean-secrets            Delete proxy CA secrets before starting to rotate the MITM CA.
           --reset-profile            Remove the saved Network Extension profile before starting.
           --help                     Show this help text.
+          --no-firwall               Don't setup the firewall
 
         Notes:
           - The transparent proxy extension is managed by macOS after `start`; this host process

--- a/proxy-lib-l4-macos/src/config.rs
+++ b/proxy-lib-l4-macos/src/config.rs
@@ -61,6 +61,10 @@ pub struct ProxyConfig {
 
     /// PEM-encoded root CA private key supplied by the host.
     pub ca_key_pem: Option<String>,
+
+    /// Disables the firewall, this is used for the first time the proxy starts and certs are not trusted yet
+    ///  The daemon will first start the proxy in this mode to obtain the cert and make it trusted.
+    pub no_firewall: bool,
 }
 
 impl Default for ProxyConfig {
@@ -73,6 +77,7 @@ impl Default for ProxyConfig {
             aikido_url: Uri::from_static("https://app.aikido.dev"),
             ca_cert_pem: None,
             ca_key_pem: None,
+            no_firewall: false,
         }
     }
 }

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -111,6 +111,7 @@ impl TcpMitmService {
             proxy_config.agent_identity.clone(),
             proxy_config.reporting_endpoint.clone(),
             proxy_config.aikido_url.clone(),
+            proxy_config.no_firewall,
         )
         .await?;
 
@@ -293,6 +294,7 @@ async fn create_firewall(
     agent_identity: Option<AgentIdentity>,
     reporting_endpoint: Option<Uri>,
     aikido_url: Uri,
+    no_firewall: bool,
 ) -> Result<Firewall, BoxError> {
     let data_path = maybe_data_path.context("(app) data path is missing")?;
 
@@ -308,6 +310,12 @@ async fn create_firewall(
 
     let https_client = new_http_client_for_internal(Executor::graceful(guard.clone()))
         .context("create firewall's inner http(s) client")?;
+
+
+    if no_firewall {
+        tracing::warn!("Starting without firewall due to the --no-firewall startup flag");
+        return Firewall::empty().await;
+    }
 
     // ensure to not wait for firewall creation in case shutdown was initiated,
     // this can happen for example in case remote lists need to be fetched and the

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -311,7 +311,6 @@ async fn create_firewall(
     let https_client = new_http_client_for_internal(Executor::graceful(guard.clone()))
         .context("create firewall's inner http(s) client")?;
 
-
     if no_firewall {
         tracing::warn!("Starting without firewall due to the --no-firewall startup flag");
         return Firewall::empty().await;

--- a/proxy-lib/src/http/firewall/mod.rs
+++ b/proxy-lib/src/http/firewall/mod.rs
@@ -91,6 +91,16 @@ impl Firewall {
             .context("aikido_url should always produce a valid absolute http(s) origin")
     }
 
+    pub async fn empty() -> Result<Self, BoxError> {
+        Ok(Self {
+            block_rules: Arc::from([]),
+            notifier: None,
+            passthrough_list: None,
+            agent_identity: None,
+            remote_endpoint_config: None,
+        })
+    }
+
     pub async fn try_new(
         guard: ShutdownGuard,
         client: impl Service<Request, Output = Response, Error = OpaqueError> + Clone,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added no_firewall flag to ProxyConfig and default initialization
* Propagated no_firewall flag into firewall creation in TCP service
* Exposed noFirewall option in host CLI and engine payload
* Added Firewall::empty constructor to support disabled-firewall runtime mode


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109051652?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->