### PR TITLE
Fix repeated access prompts for packages with pending requests

### DIFF
--- a/internal/ingress/store.go
+++ b/internal/ingress/store.go
@@ -17,6 +17,9 @@ type eventStore struct {
 // Add appends the event to the store and returns the saved event.
 // When the store exceeds maxEvents the oldest entries are discarded.
 func (e *eventStore) Add(ev BlockEvent) BlockEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	blocked := BlockEvent{
 		ID:          uuid.New().String(),
 		TsMs:        ev.TsMs,
@@ -32,8 +35,6 @@ func (e *eventStore) Add(ev BlockEvent) BlockEvent {
 		}
 	}
 
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	e.events = append(e.events, blocked)
 	if len(e.events) > maxEvents {
 		e.events = e.events[len(e.events)-maxEvents:]

--- a/internal/ingress/store.go
+++ b/internal/ingress/store.go
@@ -25,6 +25,12 @@ func (e *eventStore) Add(ev BlockEvent) BlockEvent {
 		Status:      "blocked",
 		Count:       1,
 	}
+	// If the user already requested access for this artifact, carry that request status forward
+	for i := range e.events {
+		if e.events[i].Artifact == ev.Artifact && e.events[i].Status != "blocked" {
+			blocked.Status = e.events[i].Status
+		}
+	}
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/internal/ingress/store_test.go
+++ b/internal/ingress/store_test.go
@@ -2,6 +2,35 @@ package ingress
 
 import "testing"
 
+func TestAdd_PreservesNonBlockedStatusFromExistingEvent(t *testing.T) {
+	store := &eventStore{
+		events: []BlockEvent{
+			{
+				ID:   "existing-1",
+				TsMs: 500,
+				Artifact: Artifact{
+					Product:     "npm",
+					PackageName: "evil-pkg",
+				},
+				Status: "allowed",
+			},
+		},
+	}
+
+	got := store.Add(BlockEvent{
+		TsMs: 1000,
+		Artifact: Artifact{
+			Product:     "npm",
+			PackageName: "evil-pkg",
+		},
+		BlockReason: "malware",
+	})
+
+	if got.Status != "allowed" {
+		t.Fatalf("expected status to be preserved as %q, got %q", "allowed", got.Status)
+	}
+}
+
 func TestMergeChromeBlockIfDuplicate_MergesMatchingArtifact(t *testing.T) {
 	store := &eventStore{
 		events: []BlockEvent{


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Carried forward existing non-blocked status for duplicate artifact events

**🔧 Refactors**
* Locked mutex at start of Add to ensure thread safety


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109094350?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->