### PR TITLE
Trigger proxy config refresh when tray icon is clicked

### DIFF
--- a/internal/ingress/config_refresh_handler.go
+++ b/internal/ingress/config_refresh_handler.go
@@ -1,0 +1,47 @@
+package ingress
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+var configRefreshHTTPClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+func (s *Server) handleConfigRefresh(w http.ResponseWriter, r *http.Request) {
+	if !s.validateUIToken(w, r) {
+		return
+	}
+
+	token := s.config.Token
+	if token == "" {
+		http.Error(w, "no aikido token configured", http.StatusPreconditionFailed)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, "http://mitm.ramaproxy.org/config/refresh", nil)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to build refresh request: %v", err), http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Authorization", token)
+
+	resp, err := configRefreshHTTPClient.Do(req)
+	if err != nil {
+		log.Printf("ingress: config refresh: %v", err)
+		http.Error(w, fmt.Sprintf("config refresh failed: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Printf("ingress: config refresh: proxy returned %s", resp.Status)
+		http.Error(w, fmt.Sprintf("proxy returned %s", resp.Status), resp.StatusCode)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/ingress/config_refresh_handler.go
+++ b/internal/ingress/config_refresh_handler.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/AikidoSec/safechain-internals/internal/proxy"
 )
 
 var configRefreshHTTPClient = &http.Client{
@@ -22,7 +24,7 @@ func (s *Server) handleConfigRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, "http://mitm.ramaproxy.org/config/refresh", nil)
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, proxy.L4HijackBaseURL+"/config/refresh", nil)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to build refresh request: %v", err), http.StatusInternalServerError)
 		return

--- a/internal/ingress/server.go
+++ b/internal/ingress/server.go
@@ -95,6 +95,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("POST /v1/setup/restart", s.handleSetupRestart)
 
 	mux.HandleFunc("POST /v1/logs/collect", s.handleCollectLogs)
+	mux.HandleFunc("POST /v1/config/refresh", s.handleConfigRefresh)
 
 	listener, err := net.Listen("tcp", DefaultBind)
 	if err != nil {

--- a/internal/proxy/ca.go
+++ b/internal/proxy/ca.go
@@ -37,7 +37,8 @@ func ProxyCAInstalled() bool {
 	return true
 }
 
-const l4HijackCAURL = "http://mitm.ramaproxy.org/data/root.ca.pem"
+const L4HijackBaseURL = "http://mitm.ramaproxy.org"
+const l4HijackCAURL = L4HijackBaseURL + "/data/root.ca.pem"
 
 func DownloadCACertFromL7Proxy() error {
 	metaUrl, _, _, err := GetMetaUrls()

--- a/ui/daemon/client.go
+++ b/ui/daemon/client.go
@@ -423,6 +423,19 @@ func RequestAccess(eventID string) error {
 	return nil
 }
 
+func RefreshConfig() error {
+	resp, err := doRequest(http.MethodPost, "/v1/config/refresh", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("config refresh: %s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
 func CollectLogs() error {
 	resp, err := doRequestWithClient(collectLogsHTTPClient, http.MethodPost, "/v1/logs/collect", nil)
 	if err != nil {

--- a/ui/daemonservice.go
+++ b/ui/daemonservice.go
@@ -109,6 +109,10 @@ func (s *DaemonService) CloseInstallWindow() {
 	}
 }
 
+func (s *DaemonService) RefreshConfig() error {
+	return daemon.RefreshConfig()
+}
+
 func (s *DaemonService) CollectLogs() error {
 	return daemon.CollectLogs()
 }

--- a/ui/main.go
+++ b/ui/main.go
@@ -362,6 +362,11 @@ func setupSystemTray(app *application.App, showDashboard func(), notifWindow *ap
 		if notifWindow.IsVisible() {
 			notifWindow.Hide()
 		}
+		go func() {
+			if err := daemon.RefreshConfig(); err != nil {
+				log.Printf("config refresh on tray click: %v", err)
+			}
+		}()
 		systray.OpenMenu()
 	}
 	systray.OnClick(hideNotifAndOpenMenu)


### PR DESCRIPTION
Adds a `POST /v1/config/refresh` daemon endpoint that forwards the request to the proxy's hijack domain to refresh firewall and passthrough config. The UI fires this in the background on every tray icon click/right-click.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added POST /v1/config/refresh endpoint that forwarded refresh to proxy.

**⚡ Enhancements**
* Exposed RefreshConfig method on DaemonService for frontend invocation.
* Replaced hardcoded proxy URL with proxy.L4HijackBaseURL constant usage.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109563952?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->