### PR TITLE
Add upgrade marker handling for macOS installer

### DIFF
--- a/internal/ingress/setup_handler.go
+++ b/internal/ingress/setup_handler.go
@@ -24,7 +24,14 @@ func IsSetupOk(ctx context.Context, cfg *config.ConfigInfo) bool {
 // The package installer creates an install marker file in the run directory;
 // if that file's modification time is after the last system boot, the user
 // has not rebooted since (re)installing.
+//
+// During an upgrade the preinstall script drops an upgrade marker so we can
+// skip the reboot prompt — upgrades reuse the existing kernel/extension state
+// and don't require the user to reboot.
 func IsRebootRequired() bool {
+	if _, err := os.Stat(platform.GetUpgradeMarkerPath()); err == nil {
+		return false
+	}
 	bootTime, err := platform.GetSystemBootTime()
 	if err != nil || bootTime.IsZero() {
 		return false

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -77,3 +77,7 @@ func GetConfigPath() string {
 func GetInstallMarkerPath() string {
 	return filepath.Join(config.RunDir, ".installed_at")
 }
+
+func GetUpgradeMarkerPath() string {
+	return filepath.Join(config.RunDir, ".upgraded")
+}

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -5,9 +5,16 @@ set -e
 echo "Aikido Endpoint Protection Installer - Pre-installation"
 
 UNINSTALL_SCRIPT="/Applications/Aikido Endpoint Protection.app/Contents/Resources/scripts/uninstall"
+RUN_DIR="/Library/Application Support/AikidoSecurity/EndpointProtection/run"
+UPGRADE_MARKER="$RUN_DIR/.upgraded"
 
 if [ -x "$UNINSTALL_SCRIPT" ]; then
     "$UNINSTALL_SCRIPT" --upgrade
+    mkdir -p "$RUN_DIR"
+    touch "$UPGRADE_MARKER"
+    chown root:wheel "$UPGRADE_MARKER"
+    chmod 644 "$UPGRADE_MARKER"
+    echo "Created upgrade marker at $UPGRADE_MARKER"
 else
     echo "No existing installation found, skipping cleanup"
 fi


### PR DESCRIPTION
- Introduced an upgrade marker file creation in the preinstall script to indicate when an upgrade occurs, allowing the system to skip unnecessary reboot prompts.
- Added a new function in the platform package to retrieve the upgrade marker path.
- Updated the IsRebootRequired function to check for the presence of the upgrade marker, enhancing the reboot requirement logic during upgrades.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added function to return upgrade marker path in platform package
* Updated reboot check to skip reboot when upgrade marker file existed


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109564338?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->