### PR TITLE
chore: bump rama + deps; adapt l4-macos to BridgeIo handler API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const_format"
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -1278,9 +1278,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1373,10 +1373,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1419,9 +1421,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1445,12 +1447,11 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -1507,9 +1508,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lol_html"
-version = "2.7.2"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff94cb6aef6ee52afd2c69331e9109906d855e82bd241f3110dfdf6185899ab"
+checksum = "6888e8653f6e49cb2924c660fc367a8beeb6239b71e117fa082153c6ea44d427"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2086,9 +2087,9 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psl"
-version = "2.1.204"
+version = "2.1.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e3200a2474f99d0ea576a7c76aabda7cdcc795cc27f2d93f30ab79867820d"
+checksum = "194b4aac978e4e46f782a95ecdb06bc69919c935e783984e5f5b817545881beb"
 dependencies = [
  "psl-types",
 ]
@@ -2133,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "rama"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "base64",
@@ -2208,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "rama-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "asynk-strim",
@@ -2232,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "rama-crypto"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2248,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "bindgen 0.72.1",
@@ -2267,12 +2268,12 @@ dependencies = [
 [[package]]
 name = "rama-error"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 
 [[package]]
 name = "rama-grpc"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2297,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "rama-grpc-build"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2313,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "rama-haproxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2324,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "rama-http"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "async-compression",
@@ -2361,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "rama-http-backend"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2380,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "rama-http-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "atomic-waker",
@@ -2405,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "rama-http-headers"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "base64",
@@ -2425,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "rama-http-types"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "bytes",
@@ -2453,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "rama-macros"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2464,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "rama-net"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "const_format",
@@ -2496,8 +2497,9 @@ dependencies = [
 [[package]]
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
+ "bindgen 0.72.1",
  "libc",
  "parking_lot",
  "pin-project-lite",
@@ -2513,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "rama-proxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2529,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "rama-socks5"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "byteorder",
  "rama-core",
@@ -2544,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "rama-tcp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2560,7 +2562,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-boring"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "brotli",
@@ -2585,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-rustls"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2605,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "rama-ua"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "ahash",
  "itertools 0.14.0",
@@ -2622,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "rama-udp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "rama-core",
  "rama-dns",
@@ -2634,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "rama-unix"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2646,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "rama-utils"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "const_format",
  "parking_lot",
@@ -2663,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "rama-ws"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d4d9a69c2e7be138580a6e259ee260f78e38c005#d4d9a69c2e7be138580a6e259ee260f78e38c005"
+source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 dependencies = [
  "flate2",
  "rama-core",
@@ -2831,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2858,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2894,9 +2896,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3110,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -3913,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3926,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3936,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3949,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4391,9 +4393,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ windows-sys = "0.61"
 
 [workspace.dependencies.rama]
 git = "https://github.com/plabayo/rama"
-rev = "d4d9a69c2e7be138580a6e259ee260f78e38c005"
+rev = "d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 
 [workspace.dependencies.rama-core]
 git = "https://github.com/plabayo/rama"
-rev = "d4d9a69c2e7be138580a6e259ee260f78e38c005"
+rev = "d891913bd5e73d8b8aedaa447f9954745cf5fb61"
 
 [profile.release]
 strip = true

--- a/packaging/macos/xcode/l4-proxy/Project.dev.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dev.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: d4d9a69c2e7be138580a6e259ee260f78e38c005
+    revision: d891913bd5e73d8b8aedaa447f9954745cf5fb61
   X509:
     url: https://github.com/apple/swift-certificates.git
     from: 1.0.0

--- a/packaging/macos/xcode/l4-proxy/Project.dev.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dev.yml
@@ -51,6 +51,8 @@ targets:
     dependencies:
       - package: RamaAppleNetworkExtension
         product: RamaAppleNetworkExtension
+      - package: RamaAppleNetworkExtension
+        product: RamaAppleSecureEnclave
     postBuildScripts:
       - name: Bump CFBundleVersion
         script: |

--- a/packaging/macos/xcode/l4-proxy/Project.dist.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dist.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: d4d9a69c2e7be138580a6e259ee260f78e38c005
+    revision: d891913bd5e73d8b8aedaa447f9954745cf5fb61
   X509:
     url: https://github.com/apple/swift-certificates.git
     from: 1.0.0

--- a/packaging/macos/xcode/l4-proxy/Project.dist.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dist.yml
@@ -58,6 +58,8 @@ targets:
     dependencies:
       - package: RamaAppleNetworkExtension
         product: RamaAppleNetworkExtension
+      - package: RamaAppleNetworkExtension
+        product: RamaAppleSecureEnclave
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.aikido.endpoint.proxy.l4.dist.extension

--- a/proxy-lib-l4-macos/src/handler.rs
+++ b/proxy-lib-l4-macos/src/handler.rs
@@ -1,12 +1,13 @@
-use std::{convert::Infallible, future::Future};
+use std::{convert::Infallible, future::Future, time::Duration};
 
 use rama::{
     Service,
     error::BoxError,
+    io::BridgeIo,
     net::{
         address::{Host, HostWithPort},
         apple::networkextension::{
-            TcpFlow, UdpFlow,
+            NwTcpStream, NwUdpSocket, TcpFlow, UdpFlow,
             tproxy::{
                 FlowAction, TransparentProxyConfig, TransparentProxyFlowAction,
                 TransparentProxyFlowMeta, TransparentProxyFlowProtocol, TransparentProxyHandler,
@@ -20,9 +21,12 @@ use rama::{
     telemetry::tracing,
     utils::str::any_starts_with_ignore_ascii_case,
 };
-use safechain_proxy_lib::nostd::net::is_passthrough_ip;
+use safechain_proxy_lib::{
+    nostd::net::is_passthrough_ip,
+    tcp::{is_known_http_port, is_known_tls_port},
+};
 
-type UdpFlowService = BoxService<UdpFlow, (), Infallible>;
+type UdpFlowService = BoxService<BridgeIo<UdpFlow, NwUdpSocket>, (), Infallible>;
 
 #[derive(Debug, Clone)]
 pub struct FlowHandlerFactory;
@@ -70,23 +74,50 @@ impl TransparentProxyHandler for FlowHandler {
         &self,
         exec: Executor,
         meta: TransparentProxyFlowMeta,
-    ) -> impl Future<Output = FlowAction<impl Service<TcpFlow, Output = (), Error = Infallible>>>
-    + Send
+    ) -> impl Future<
+        Output = FlowAction<
+            impl Service<BridgeIo<TcpFlow, NwTcpStream>, Output = (), Error = Infallible>,
+        >,
+    > + Send
     + '_ {
         let action = if self.tcp_mitm_service.is_passthrough_flow(&meta) {
-            tracing::warn!(
-                protocol = ?meta.source_app_bundle_identifier,
-                "passthrough: app bundle matches passthrough for any domain"
+            tracing::debug!(
+                app_bundle = ?meta.source_app_bundle_identifier,
+                remote = ?meta.remote_endpoint,
+                "passthrough: app bundle matches passthrough (for any domain)"
             );
             FlowAction::Passthrough
         } else if is_configured_cidr_passthrough(&meta, &self.tcp_mitm_service) {
+            tracing::debug!(
+                app_bundle = ?meta.source_app_bundle_identifier,
+                remote = ?meta.remote_endpoint,
+                "passthrough: CIDR for remote endpoint matches passthrough"
+            );
             FlowAction::Passthrough
         } else {
             match flow_action(&meta) {
-                TransparentProxyFlowAction::Intercept => FlowAction::Intercept {
-                    service: self.tcp_mitm_service.new_intercept_service(exec),
-                    meta,
-                },
+                TransparentProxyFlowAction::Intercept => {
+                    let port = meta.remote_endpoint.as_ref().map(|e| e.port).unwrap_or(0);
+                    let cfg = self.tcp_mitm_service.proxy_config();
+                    let tls_peek_duration = peek_duration(if is_known_tls_port(port) {
+                        cfg.peek_duration_s
+                    } else {
+                        cfg.peek_unknown_port_duration_s
+                    });
+                    let http_peek_duration = peek_duration(if is_known_http_port(port) {
+                        cfg.peek_duration_s
+                    } else {
+                        cfg.peek_unknown_port_duration_s
+                    });
+                    FlowAction::Intercept {
+                        service: self.tcp_mitm_service.new_intercept_service(
+                            exec,
+                            tls_peek_duration,
+                            http_peek_duration,
+                        ),
+                        meta,
+                    }
+                }
                 TransparentProxyFlowAction::Passthrough => FlowAction::Passthrough,
                 TransparentProxyFlowAction::Blocked => FlowAction::Blocked,
             }
@@ -99,8 +130,11 @@ impl TransparentProxyHandler for FlowHandler {
         &self,
         _exec: Executor,
         meta: TransparentProxyFlowMeta,
-    ) -> impl Future<Output = FlowAction<impl Service<UdpFlow, Output = (), Error = Infallible>>>
-    + Send
+    ) -> impl Future<
+        Output = FlowAction<
+            impl Service<BridgeIo<UdpFlow, NwUdpSocket>, Output = (), Error = Infallible>,
+        >,
+    > + Send
     + '_ {
         let action = if self.tcp_mitm_service.is_passthrough_flow(&meta) {
             tracing::warn!(
@@ -130,6 +164,10 @@ impl TransparentProxyHandler for FlowHandler {
 
         std::future::ready(action)
     }
+}
+
+fn peek_duration(seconds: f64) -> Duration {
+    Duration::from_secs_f64(seconds.max(0.001))
 }
 
 fn flow_action(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {

--- a/proxy-lib-l4-macos/src/tcp.rs
+++ b/proxy-lib-l4-macos/src/tcp.rs
@@ -23,12 +23,11 @@ use rama::{
     layer::{ArcLayer, ConsumeErrLayer, HijackLayer},
     net::{
         apple::networkextension::{
-            TcpFlow,
+            NwTcpStream, TcpFlow,
             tproxy::{TransparentProxyFlowMeta, TransparentProxyServiceContext},
         },
-        client::{ConnectorService, EstablishedClientConnection},
         http::server::HttpPeekRouter,
-        proxy::{IoForwardService, ProxyTarget},
+        proxy::IoForwardService,
         tls::server::PeekTlsClientHelloService,
     },
     proxy::socks5::{proxy::mitm::Socks5MitmRelayService, server::Socks5PeekRouter},
@@ -53,21 +52,22 @@ use safechain_proxy_lib::{
         ws_relay::WebSocketMitmRelayService,
     },
     storage,
-    tcp::{is_known_http_port, is_known_tls_port, new_tcp_connector_service_for_proxy},
     tls::{RootCaKeyPair, mitm_relay_policy::TlsMitmRelayPolicyLayer},
     utils::token::AgentIdentity,
 };
 
 type TcpTlsMitmRelay = TlsMitmRelay<CachedBoringMitmCertIssuer<InMemoryBoringMitmCertIssuer>>;
 
-#[derive(Clone)]
-pub(super) struct TcpMitmService {
+struct TcpMitmServiceInner {
     proxy_config: ProxyConfig,
     tls_mitm_relay_policy: TlsMitmRelayPolicyLayer,
     tls_mitm_relay: TcpTlsMitmRelay,
     firewall: Firewall,
     ca_crt_pem_bytes: &'static [u8],
 }
+
+#[derive(Clone)]
+pub(super) struct TcpMitmService(Arc<TcpMitmServiceInner>);
 
 impl TcpMitmService {
     pub(super) async fn try_new(ctx: TransparentProxyServiceContext) -> Result<Self, BoxError> {
@@ -117,19 +117,30 @@ impl TcpMitmService {
 
         tracing::debug!("creating tcp mitm state for transparent proxy extension");
 
-        Ok(Self {
+        Ok(Self(Arc::new(TcpMitmServiceInner {
             proxy_config,
             tls_mitm_relay_policy: TlsMitmRelayPolicyLayer::new(firewall.clone()),
             tls_mitm_relay: TlsMitmRelay::new_cached_in_memory(ca_crt, ca_key),
             firewall,
             ca_crt_pem_bytes,
-        })
+        })))
     }
 
-    pub(super) fn new_intercept_service(&self, exec: Executor) -> TcpInterceptService {
+    pub(super) fn proxy_config(&self) -> &ProxyConfig {
+        &self.0.proxy_config
+    }
+
+    pub(super) fn new_intercept_service(
+        &self,
+        exec: Executor,
+        tls_peek_duration: Duration,
+        http_peek_duration: Duration,
+    ) -> TcpInterceptService {
         TcpInterceptService {
             mitm: self.clone(),
             exec,
+            tls_peek_duration,
+            http_peek_duration,
         }
     }
 
@@ -138,7 +149,8 @@ impl TcpMitmService {
             return false;
         };
 
-        self.firewall
+        self.0
+            .firewall
             .is_passthrough_traffic(&PassthroughMatchContext {
                 app_bundle_id: Some(bundle_id),
                 domain: None,
@@ -146,7 +158,7 @@ impl TcpMitmService {
     }
 
     pub fn is_passthrough_destination(&self, addr: std::net::IpAddr) -> bool {
-        self.firewall.is_passthrough_destination(addr)
+        self.0.firewall.is_passthrough_destination(addr)
     }
 
     fn new_bridge_service<Ingress, Egress>(
@@ -162,11 +174,10 @@ impl TcpMitmService {
     {
         new_tcp_service_inner(
             exec,
-            self.proxy_config.clone(),
-            self.tls_mitm_relay_policy.clone(),
-            self.tls_mitm_relay.clone(),
-            self.firewall.clone(),
-            self.ca_crt_pem_bytes,
+            self.0.tls_mitm_relay_policy.clone(),
+            self.0.tls_mitm_relay.clone(),
+            self.0.firewall.clone(),
+            self.0.ca_crt_pem_bytes,
             within_connect_tunnel,
             tls_peek_duration,
             http_peek_duration,
@@ -177,7 +188,6 @@ impl TcpMitmService {
 #[allow(clippy::too_many_arguments)]
 fn new_tcp_service_inner<Issuer, Ingress, Egress>(
     exec: Executor,
-    proxy_config: ProxyConfig,
     tls_mitm_relay_policy: TlsMitmRelayPolicyLayer,
     tls_mitm_relay: TlsMitmRelay<Issuer>,
     firewall: Firewall,
@@ -194,7 +204,6 @@ where
     let http_mitm_svc =
         HttpMitmRelay::new(exec.clone()).with_http_middleware(http_relay_middleware(
             exec,
-            proxy_config,
             tls_mitm_relay_policy.clone(),
             tls_mitm_relay.clone(),
             firewall,
@@ -229,7 +238,6 @@ where
 #[allow(clippy::too_many_arguments)]
 fn http_relay_middleware<S, Issuer>(
     exec: Executor,
-    proxy_config: ProxyConfig,
     tls_mitm_relay_policy: TlsMitmRelayPolicyLayer,
     tls_mitm_relay: TlsMitmRelay<Issuer>,
     firewall: Firewall,
@@ -253,7 +261,6 @@ where
     } else {
         new_tcp_service_inner(
             exec.clone(),
-            proxy_config,
             tls_mitm_relay_policy,
             tls_mitm_relay,
             firewall.clone(),
@@ -347,62 +354,24 @@ async fn create_firewall(
 pub(super) struct TcpInterceptService {
     mitm: TcpMitmService,
     exec: Executor,
+    tls_peek_duration: Duration,
+    http_peek_duration: Duration,
 }
 
-impl Service<TcpFlow> for TcpInterceptService {
+impl Service<BridgeIo<TcpFlow, NwTcpStream>> for TcpInterceptService {
     type Output = ();
     type Error = Infallible;
 
-    async fn serve(&self, ingress: TcpFlow) -> Result<Self::Output, Self::Error> {
-        let Some(ProxyTarget(egress_addr)) = ingress.extensions().get_ref().cloned() else {
-            tracing::debug!("missing ProxyTarget in transparent proxy tcp service");
-            return Ok(());
-        };
-
-        let connector = new_tcp_connector_service_for_proxy(self.exec.clone());
-        let tcp_req = rama::tcp::client::Request::new_with_extensions(
-            egress_addr.clone(),
-            ingress.extensions().clone(),
-        );
-
-        let EstablishedClientConnection { conn: egress, .. } =
-            match connector.connect(tcp_req).await {
-                Ok(connection) => connection,
-                Err(err) => {
-                    tracing::debug!(
-                        address = %egress_addr,
-                        error = %err.into_box_error(),
-                        "transparent proxy tcp connect failed"
-                    );
-                    return Ok(());
-                }
-            };
-
-        let cfg = &self.mitm.proxy_config;
-        let port = egress_addr.port;
-        let tls_peek_duration = Duration::from_secs_f64(
-            if is_known_tls_port(port) {
-                cfg.peek_duration_s
-            } else {
-                cfg.peek_unknown_port_duration_s
-            }
-            .max(0.001),
-        );
-        let http_peek_duration = Duration::from_secs_f64(
-            if is_known_http_port(port) {
-                cfg.peek_duration_s
-            } else {
-                cfg.peek_unknown_port_duration_s
-            }
-            .max(0.001),
-        );
+    async fn serve(
+        &self,
+        bridge: BridgeIo<TcpFlow, NwTcpStream>,
+    ) -> Result<Self::Output, Self::Error> {
         let mitm_svc = self.mitm.new_bridge_service(
             self.exec.clone(),
             false,
-            tls_peek_duration,
-            http_peek_duration,
+            self.tls_peek_duration,
+            self.http_peek_duration,
         );
-        let _ = mitm_svc.serve(BridgeIo(ingress, egress)).await;
-        Ok(())
+        mitm_svc.serve(bridge).await
     }
 }


### PR DESCRIPTION
- Bump rama rev + workspace deps.
- Rama's tproxy handler now returns services over `BridgeIo<Flow, Nw*>` (egress is established by Swift). Adapt l4-macos accordingly: drop the egress connector, move peek-duration calc into `match_tcp_flow`, wrap `TcpMitmService` in `Arc<Inner>` to cut per-flow cloning.

Make sure test this one internally for a while, before shipping to customer.
Should be ok, and hopefully improve things a lot. But still...
it is one with high impact so want to be really sure about this one.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added RamaAppleSecureEnclave package dependency for SecureEnclave access

**⚡ Enhancements**
* Updated Rama dependency revision across Xcode project manifests

**🔧 Refactors**
* Adapted transparent proxy handlers to return BridgeIo-based services
* Removed egress connector and moved peek-duration into match_tcp_flow
* Wrapped TcpMitmService inner state in Arc to reduce cloning


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109611868?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->