### PR TITLE
Remove focus call on notification window

### DIFF
--- a/ui/main.go
+++ b/ui/main.go
@@ -374,7 +374,6 @@ func setupSystemTray(app *application.App, showDashboard func(), notifWindow *ap
 		systray.PositionWindow(notifWindow, 2)
 		systray.WindowDebounce(200 * time.Millisecond)
 		notifWindow.Show()
-		notifWindow.Focus()
 	}
 
 	go func() {


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Removed call to Focus() when showing tray notification window


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109898103?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->