### PR TITLE
Use precise system timestamp for blocked events

### DIFF
--- a/proxy-lib/src/http/firewall/events.rs
+++ b/proxy-lib/src/http/firewall/events.rs
@@ -49,7 +49,7 @@ pub struct BlockedEvent {
 impl BlockedEvent {
     pub fn from_info(info: BlockedEventInfo) -> Self {
         Self {
-            ts_ms: SystemTimestampMilliseconds::now(),
+            ts_ms: SystemTimestampMilliseconds::now_precise(),
             artifact: info.artifact,
             block_reason: info.block_reason,
         }

--- a/proxy-lib/src/utils/time.rs
+++ b/proxy-lib/src/utils/time.rs
@@ -102,6 +102,12 @@ impl SystemTimestampMilliseconds {
         Self(now_unix_ms())
     }
 
+    /// Returns the current timestamp using `SystemTime::now()` directly,
+    /// bypassing the cached/approximate value from `now_unix_ms`.
+    pub fn now_precise() -> Self {
+        SystemTime::now().into()
+    }
+
     #[cfg(test)]
     pub fn is_positive_epoch_msg(self) -> bool {
         self.0 > 0


### PR DESCRIPTION
`now_unix_ms()` returns a cached/approximate value unsuitable for event timestamps. Add `now_precise()` that reads `SystemTime` directly and use it in `BlockedEvent::from_info`.