### PR TITLE
update rama to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "rama"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "base64",
@@ -2209,7 +2209,7 @@ dependencies = [
 [[package]]
 name = "rama-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "asynk-strim",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "rama-crypto"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "rama-dns"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "bindgen 0.72.1",
@@ -2268,12 +2268,12 @@ dependencies = [
 [[package]]
 name = "rama-error"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 
 [[package]]
 name = "rama-grpc"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "rama-grpc-build"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "rama-haproxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "rama-http"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "async-compression",
@@ -2362,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "rama-http-backend"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "rama-http-core"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "atomic-waker",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "rama-http-headers"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "base64",
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "rama-http-types"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "bytes",
@@ -2454,7 +2454,7 @@ dependencies = [
 [[package]]
 name = "rama-macros"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "rama-net"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "const_format",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "bindgen 0.72.1",
  "libc",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "rama-proxy"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "rama-socks5"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "byteorder",
  "rama-core",
@@ -2546,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "rama-tcp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2562,7 +2562,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-boring"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "brotli",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "rama-tls-rustls"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "pin-project-lite",
  "rama-core",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "rama-ua"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "ahash",
  "itertools 0.14.0",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "rama-udp"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "rama-core",
  "rama-dns",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "rama-unix"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2648,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "rama-utils"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "const_format",
  "parking_lot",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "rama-ws"
 version = "0.3.0-rc1"
-source = "git+https://github.com/plabayo/rama?rev=d891913bd5e73d8b8aedaa447f9954745cf5fb61#d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+source = "git+https://github.com/plabayo/rama?rev=e4bdf3acb5a769083b3a78cb364aea2a64e05881#e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 dependencies = [
  "flate2",
  "rama-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ windows-sys = "0.61"
 
 [workspace.dependencies.rama]
 git = "https://github.com/plabayo/rama"
-rev = "d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+rev = "e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 
 [workspace.dependencies.rama-core]
 git = "https://github.com/plabayo/rama"
-rev = "d891913bd5e73d8b8aedaa447f9954745cf5fb61"
+rev = "e4bdf3acb5a769083b3a78cb364aea2a64e05881"
 
 [profile.release]
 strip = true

--- a/packaging/macos/xcode/l4-proxy/Project.dev.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dev.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: d891913bd5e73d8b8aedaa447f9954745cf5fb61
+    revision: e4bdf3acb5a769083b3a78cb364aea2a64e05881
   X509:
     url: https://github.com/apple/swift-certificates.git
     from: 1.0.0

--- a/packaging/macos/xcode/l4-proxy/Project.dist.yml
+++ b/packaging/macos/xcode/l4-proxy/Project.dist.yml
@@ -7,7 +7,7 @@ options:
 packages:
   RamaAppleNetworkExtension:
     url: https://github.com/plabayo/rama.git
-    revision: d891913bd5e73d8b8aedaa447f9954745cf5fb61
+    revision: e4bdf3acb5a769083b3a78cb364aea2a64e05881
   X509:
     url: https://github.com/apple/swift-certificates.git
     from: 1.0.0


### PR DESCRIPTION
this comes with some minor improvements in tproxy macos flow, but also with a big improvement that original flow data (ingress) is now applied on egress flow

this ensures that traffic going through the macos l4 proxy, remains seen as data coming from original source
(e.g. vscode will still be seen as coming from vscode,
 instead of your proxy (bundle id))

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated RamaAppleNetworkExtension package revision in macOS Xcode project files


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109948439?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->