### PR TITLE
Only skip minimum age check for wildcard matches in allowed list

### DIFF
--- a/proxy-lib/src/endpoint_protection/policy.rs
+++ b/proxy-lib/src/endpoint_protection/policy.rs
@@ -15,8 +15,15 @@ use crate::{
 pub enum PackagePolicyDecision {
     /// No policy rule matched — defer to the next check (e.g. the malware list).
     Defer,
-    /// An explicit allow rule matched — bypass all further checks for this package.
+    /// An exact-match `allowed_packages` entry matched (typically the shape an
+    /// approval-flow approval takes). Bypasses install-policy gates AND the
+    /// malware check, but the package is still subject to the min-age check —
+    /// approving a package by name does not vouch for brand-new versions of it.
     Allow,
+    /// A wildcard `allowed_packages` pattern matched (e.g. `@aikidosec/*`).
+    /// Treated as a "trust the whole namespace, all versions" signal: bypasses
+    /// install-policy gates AND malware AND min-age.
+    AllowSkipAgeCheck,
     /// Package is in the `rejected_packages` list — block immediately.
     Rejected,
     /// `block_all_installs` is enabled — block all installs for this ecosystem.
@@ -75,6 +82,20 @@ impl<K: PackageName + Hash> PolicyEvaluator<K> {
                 Self::evaluate_package_install_for_typed_ecosystem_config(config, package_name)
             })
             .unwrap_or(PackagePolicyDecision::Defer)
+    }
+
+    /// Test constructor: build a [`PolicyEvaluator`] populated directly from a
+    /// raw [`EcosystemConfig`], bypassing the broadcast/async refresh path.
+    #[cfg(test)]
+    pub(crate) fn for_tests(ecosystem_config: &super::EcosystemConfig) -> Self
+    where
+        K: PackageName + Eq + Hash,
+    {
+        let cached = Arc::new(ArcSwapOption::const_empty());
+        cached.store(Some(Arc::new(TypedEcosystemConfig::from_raw(
+            ecosystem_config,
+        ))));
+        Self { cached }
     }
 
     pub fn package_age_cutoff_ts(
@@ -166,13 +187,28 @@ impl<K: PackageName + Hash> PolicyEvaluator<K> {
             return PackagePolicyDecision::Rejected;
         }
 
+        // Wildcards (e.g. `@aikidosec/*`) signal "trust the whole namespace,
+        // all versions" and bypass min-age too. Exact-match entries (e.g. an
+        // approval-flow approval) bypass the malware check but stay subject to
+        // min-age — approving a package name doesn't vouch for brand-new
+        // versions of it.
         if ecosystem_cfg
             .allowed_packages
-            .match_package_name(package_name)
+            .match_wildcard_only(package_name)
         {
             tracing::info!(
                 package = %package_name,
-                "package is explicitly allowed by endpoint protection config"
+                "package is explicitly allowed via wildcard pattern by endpoint protection config"
+            );
+            return PackagePolicyDecision::AllowSkipAgeCheck;
+        }
+        if ecosystem_cfg
+            .allowed_packages
+            .match_exact_only(package_name)
+        {
+            tracing::info!(
+                package = %package_name,
+                "package is explicitly allowed via exact-match entry by endpoint protection config"
             );
             return PackagePolicyDecision::Allow;
         }

--- a/proxy-lib/src/endpoint_protection/policy_tests.rs
+++ b/proxy-lib/src/endpoint_protection/policy_tests.rs
@@ -143,7 +143,7 @@ fn evaluate_package_install_allowed_packages_wildcard_prefix_scope() {
     };
 
     let decision = evaluate(&cfg, "@npmcli/arborist");
-    assert_eq!(PackagePolicyDecision::Allow, decision);
+    assert_eq!(PackagePolicyDecision::AllowSkipAgeCheck, decision);
 
     let decision = evaluate(&cfg, "@other/scope");
     assert_eq!(PackagePolicyDecision::BlockAll, decision);
@@ -159,7 +159,7 @@ fn evaluate_package_install_allowed_packages_wildcard_middle() {
     };
 
     let decision = evaluate(&cfg, "@types/node");
-    assert_eq!(PackagePolicyDecision::Allow, decision);
+    assert_eq!(PackagePolicyDecision::AllowSkipAgeCheck, decision);
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn evaluate_package_install_rejected_wildcard_takes_priority_over_allowed_wildca
     assert_eq!(PackagePolicyDecision::Rejected, decision);
 
     let decision = evaluate(&cfg, "pkg-good-test");
-    assert_eq!(PackagePolicyDecision::Allow, decision);
+    assert_eq!(PackagePolicyDecision::AllowSkipAgeCheck, decision);
 }
 
 #[test]
@@ -204,5 +204,77 @@ fn evaluate_package_install_star_only_allows_any_package_name() {
     };
 
     let decision = evaluate(&cfg, "anything-goes");
-    assert_eq!(PackagePolicyDecision::Allow, decision);
+    assert_eq!(PackagePolicyDecision::AllowSkipAgeCheck, decision);
+}
+
+#[test]
+fn wildcard_match_returns_allow_for_all_versions() {
+    let cfg = EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: exceptions(&["@aikidosec/*"], &[]),
+    };
+
+    assert_eq!(
+        PackagePolicyDecision::AllowSkipAgeCheck,
+        evaluate(&cfg, "@aikidosec/ci-api-client")
+    );
+}
+
+#[test]
+fn exact_match_returns_allow() {
+    // Exact-match entries (the shape approval-flow approvals take) bypass the
+    // malware check but stay subject to min-age. Only wildcards (which return
+    // `AllowSkipAgeCheck`) bypass min-age too.
+    let cfg = EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: exceptions(&["requests"], &[]),
+    };
+
+    assert_eq!(PackagePolicyDecision::Allow, evaluate(&cfg, "requests"));
+}
+
+#[test]
+fn wildcard_takes_priority_over_exact_match_when_both_match() {
+    // If both a wildcard pattern and an exact entry would match the same name,
+    // the wildcard wins because it carries the stronger trust signal.
+    let cfg = EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: exceptions(&["requests", "req*"], &[]),
+    };
+
+    assert_eq!(
+        PackagePolicyDecision::AllowSkipAgeCheck,
+        evaluate(&cfg, "requests")
+    );
+}
+
+#[test]
+fn rejected_overrides_both_allow_variants() {
+    let cfg = EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: exceptions(
+            &["@aikidosec/*", "requests"],
+            &["@aikidosec/deprecated", "requests"],
+        ),
+    };
+
+    // Exact reject wins over both flavors of allow.
+    assert_eq!(
+        PackagePolicyDecision::Rejected,
+        evaluate(&cfg, "@aikidosec/deprecated")
+    );
+    assert_eq!(PackagePolicyDecision::Rejected, evaluate(&cfg, "requests"));
+    // Sibling wildcard match still returns AllowSkipAgeCheck when not rejected.
+    assert_eq!(
+        PackagePolicyDecision::AllowSkipAgeCheck,
+        evaluate(&cfg, "@aikidosec/ci-api-client")
+    );
 }

--- a/proxy-lib/src/http/firewall/rule/chrome/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/chrome/mod.rs
@@ -140,12 +140,20 @@ impl Rule for RuleChrome {
             package_info.version,
         );
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision = policy_evaluator.evaluate_package_install(&package_info.extension_id);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 PackagePolicyDecision::BlockAll
@@ -160,7 +168,7 @@ impl Rule for RuleChrome {
             }
         }
 
-        if self.matches_malware_entry(&package_info) {
+        if !bypass_malware && self.matches_malware_entry(&package_info) {
             tracing::info!(
                 http.url.full = %req.uri(),
                 http.request.method = %req.method(),

--- a/proxy-lib/src/http/firewall/rule/golang/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/golang/mod.rs
@@ -149,6 +149,16 @@ impl Rule for RuleGolang {
         else {
             return Ok(resp);
         };
+        if let Some(policy) = self.policy_evaluator.as_ref() {
+            let name = GolangPackageName::from(module_name.as_str());
+            if policy.evaluate_package_install(&name) == PackagePolicyDecision::AllowSkipAgeCheck {
+                tracing::debug!(
+                    module = %module_name,
+                    "Go module list: module is wildcard-allowlisted, skipping min-age strip"
+                );
+                return Ok(resp);
+            }
+        }
         min_package_age
             .rewrite_list_response(
                 resp,
@@ -200,16 +210,26 @@ impl RuleGolang {
             "Go module zip download request"
         );
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let name = GolangPackageName::from(package.fully_qualified_name.as_str());
             let decision = policy_evaluator.evaluate_package_install(&name);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
                 }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
+                }
                 PackagePolicyDecision::Defer => {}
-                decision => {
+                decision @ (PackagePolicyDecision::BlockAll
+                | PackagePolicyDecision::Rejected
+                | PackagePolicyDecision::RequestInstall) => {
                     return Ok(RequestAction::Block(BlockedRequest::blocked(
                         req,
                         Self::blocked_artifact(&package),
@@ -219,7 +239,7 @@ impl RuleGolang {
             }
         }
 
-        if self.is_package_listed_as_malware(&package) {
+        if !bypass_malware && self.is_package_listed_as_malware(&package) {
             tracing::warn!("Blocked malware from {}", package.fully_qualified_name);
             return Ok(RequestAction::Block(BlockedRequest::blocked(
                 req,

--- a/proxy-lib/src/http/firewall/rule/golang/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/golang/mod.rs
@@ -271,3 +271,6 @@ impl RuleGolang {
         Ok(RequestAction::Allow(req))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/proxy-lib/src/http/firewall/rule/golang/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/golang/tests.rs
@@ -1,0 +1,126 @@
+use rama::http::{Body, Request};
+
+use crate::{
+    endpoint_protection::{EcosystemConfig, ExceptionLists, PolicyEvaluator},
+    http::firewall::events::BlockReason,
+    package::{
+        malware_list::{ListDataEntry, Reason},
+        released_packages_list::{ReleasedPackageData, RemoteReleasedPackagesList},
+    },
+    utils::time::{SystemDuration, SystemTimestampMilliseconds},
+};
+
+use super::*;
+
+fn ecosystem_config_with_allowed(allowed: &[&str]) -> EcosystemConfig {
+    EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: ExceptionLists {
+            allowed_packages: allowed.iter().map(|v| (*v).into()).collect(),
+            rejected_packages: Default::default(),
+        },
+    }
+}
+
+fn make_test_rule(
+    ecosystem_config: Option<&EcosystemConfig>,
+    malware: Vec<ListDataEntry>,
+    recent_releases: &[(&str, &str, u64)],
+) -> RuleGolang {
+    let now_ts = SystemTimestampMilliseconds::now();
+    let released_entries = recent_releases
+        .iter()
+        .map(|(name, version, hours_ago)| ReleasedPackageData {
+            package_name: (*name).to_owned(),
+            version: version.parse().unwrap(),
+            released_on: now_ts - SystemDuration::hours(*hours_ago as u16),
+        })
+        .collect();
+
+    RuleGolang {
+        target_domains: ["proxy.golang.org"].into_iter().collect(),
+        remote_malware_list: RemoteMalwareList::from_entries_for_tests(malware),
+        remote_released_packages_list: RemoteReleasedPackagesList::from_entries_for_tests(
+            released_entries,
+            now_ts,
+        ),
+        policy_evaluator: ecosystem_config.map(PolicyEvaluator::for_tests),
+        maybe_min_package_age: None,
+    }
+}
+
+fn malware_entry(name: &str, version: &str) -> ListDataEntry {
+    ListDataEntry {
+        package_name: name.to_owned(),
+        version: version.parse().unwrap(),
+        reason: Reason::Malware,
+    }
+}
+
+fn zip_request(name: &str, version: &str) -> Request {
+    let path = format!("/{name}/@v/v{version}.zip");
+    Request::builder().uri(path).body(Body::empty()).unwrap()
+}
+
+fn assert_block_reason(action: RequestAction, expected: BlockReason) {
+    match action {
+        RequestAction::Block(blocked) => assert_eq!(blocked.info.block_reason, expected),
+        RequestAction::Allow(_) => panic!("expected Block({expected:?}), got Allow"),
+    }
+}
+
+fn assert_allow(action: RequestAction) {
+    if let RequestAction::Block(blocked) = action {
+        panic!("expected Allow, got Block({:?})", blocked.info.block_reason);
+    }
+}
+
+#[tokio::test]
+async fn wildcard_allow_bypasses_min_age() {
+    let cfg = ecosystem_config_with_allowed(&["github.com/gorilla/*"]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        vec![],
+        &[("github.com/gorilla/mux", "1.8.0", 1)],
+    );
+
+    let action = rule
+        .evaluate_zip_request(zip_request("github.com/gorilla/mux", "1.8.0"))
+        .await
+        .unwrap();
+    assert_allow(action);
+}
+
+#[tokio::test]
+async fn exact_allow_does_not_bypass_min_age() {
+    let cfg = ecosystem_config_with_allowed(&["github.com/gorilla/mux"]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        vec![],
+        &[("github.com/gorilla/mux", "1.8.0", 1)],
+    );
+
+    let action = rule
+        .evaluate_zip_request(zip_request("github.com/gorilla/mux", "1.8.0"))
+        .await
+        .unwrap();
+    assert_block_reason(action, BlockReason::NewPackage);
+}
+
+#[tokio::test]
+async fn exact_allow_bypasses_malware() {
+    let cfg = ecosystem_config_with_allowed(&["github.com/gorilla/mux"]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        vec![malware_entry("github.com/gorilla/mux", "1.8.0")],
+        &[],
+    );
+
+    let action = rule
+        .evaluate_zip_request(zip_request("github.com/gorilla/mux", "1.8.0"))
+        .await
+        .unwrap();
+    assert_allow(action);
+}

--- a/proxy-lib/src/http/firewall/rule/maven/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/maven/mod.rs
@@ -146,13 +146,21 @@ impl Rule for RuleMaven {
             "Maven package download request"
         );
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision =
                 policy_evaluator.evaluate_package_install(&artifact.fully_qualified_name);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 PackagePolicyDecision::BlockAll
@@ -167,7 +175,7 @@ impl Rule for RuleMaven {
             }
         }
 
-        if self.is_package_listed_as_malware(&artifact) {
+        if !bypass_malware && self.is_package_listed_as_malware(&artifact) {
             return Ok(RequestAction::Block(BlockedRequest::blocked(
                 req,
                 artifact.into_blocked_artifact(),

--- a/proxy-lib/src/http/firewall/rule/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/mod.rs
@@ -40,8 +40,10 @@ pub(crate) fn block_reason_for(decision: PackagePolicyDecision) -> BlockReason {
         PackagePolicyDecision::Rejected => BlockReason::Rejected,
         PackagePolicyDecision::BlockAll => BlockReason::BlockAll,
         PackagePolicyDecision::RequestInstall => BlockReason::RequestInstall,
-        PackagePolicyDecision::Allow | PackagePolicyDecision::Defer => {
-            unreachable!("Allow and Defer are not blocking decisions")
+        PackagePolicyDecision::Allow
+        | PackagePolicyDecision::AllowSkipAgeCheck
+        | PackagePolicyDecision::Defer => {
+            unreachable!("Allow, AllowSkipAgeCheck and Defer are not blocking decisions")
         }
     }
 }

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
@@ -55,7 +55,11 @@ impl MinPackageAge {
         req.headers_mut().typed_insert(Accept::json());
     }
 
-    pub(super) async fn remove_new_packages(&self, resp: Response) -> Result<Response, BoxError> {
+    pub(super) async fn remove_new_packages(
+        &self,
+        resp: Response,
+        is_allowed: impl Fn(&str) -> bool,
+    ) -> Result<Response, BoxError> {
         if resp
             .headers()
             .typed_get::<ContentType>()
@@ -83,6 +87,16 @@ impl MinPackageAge {
                 return Ok(Response::from_parts(parts, Body::from(bytes)));
             }
         };
+
+        if let Some(name) = json.get("name").and_then(|n| n.as_str())
+            && is_allowed(name)
+        {
+            tracing::debug!(
+                package = %name,
+                "npm metadata response: package is allowlisted, skipping min-age strip"
+            );
+            return Ok(Response::from_parts(parts, Body::from(bytes)));
+        }
 
         let versions_to_remove = Self::get_versions_to_remove(&json, cutoff);
 

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
@@ -65,7 +65,10 @@ async fn removes_versions_newer_than_48h() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("created"));
@@ -83,7 +86,10 @@ async fn keeps_versions_older_than_48h() {
     let body = format!(r#"{{"time":{{"created":"2020-01-01T00:00:00.000Z","1.0.0":"{old}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("1.0.0"), "old version should be kept");
@@ -95,7 +101,10 @@ async fn keeps_created_and_modified_always() {
     let body = format!(r#"{{"time":{{"created":"{recent}","modified":"{recent}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(
@@ -115,7 +124,10 @@ async fn passthrough_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     assert_eq!(
         result.headers().get("content-type").unwrap(),
         "application/octet-stream"
@@ -126,7 +138,10 @@ async fn passthrough_non_json_response() {
 async fn passthrough_invalid_json_body() {
     let resp = make_json_response("not valid json {{{");
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let body_str = result.try_into_string().await.unwrap();
     assert_eq!(body_str, "not valid json {{{");
 }
@@ -140,7 +155,10 @@ async fn updates_latest_tag_when_latest_is_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -155,7 +173,10 @@ async fn updates_latest_to_most_recent_stable_version() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.1");
 }
@@ -168,7 +189,10 @@ async fn removes_latest_tag_when_no_stable_versions_remain() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -189,7 +213,10 @@ async fn preserves_latest_tag_when_latest_is_not_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -203,7 +230,10 @@ async fn excludes_prerelease_versions_from_latest_tag() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -223,7 +253,10 @@ async fn no_dist_tags_is_unchanged() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json.as_object().unwrap().get("dist-tags").is_none(),
@@ -246,7 +279,10 @@ async fn removes_response_caching() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
 
     assert!(
         result.headers().get("last-modified").is_none(),
@@ -271,7 +307,10 @@ async fn does_not_strip_headers_for_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     assert_eq!(
         result.headers().get("etag").unwrap(),
         r#""abc123""#,
@@ -294,7 +333,10 @@ async fn does_not_strip_cache_headers_when_json_is_not_modified() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
 
     assert_eq!(
         result.headers().get("etag").unwrap(),
@@ -310,5 +352,31 @@ async fn does_not_strip_cache_headers_when_json_is_not_modified() {
         result.headers().get("cache-control").unwrap(),
         "max-age=3600",
         "existing cache-control should still be there"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_allowlisted_package_is_not_rewritten() {
+    // Caller (RuleNpm::evaluate_response) only feeds `true` for `AllowSkipAgeCheck`
+    // (wildcard) decisions; this test simulates that by returning true. Exact-match
+    // entries stay subject to min-age and are gated separately at the policy layer.
+    let recent = timestamp_hours_ago(1);
+    let body = format!(
+        r#"{{"name":"@aikidosec/ci-api-client","time":{{"created":"2020-01-01T00:00:00.000Z","1.0.0":"2020-01-01T00:00:00.000Z","1.0.15":"{recent}"}}}}"#
+    );
+    let resp = make_json_response(&body);
+    let min_package_age = MinPackageAge::new(None, None);
+    let is_allowed = |name: &str| name == "@aikidosec/ci-api-client";
+
+    let result = min_package_age
+        .remove_new_packages(resp, is_allowed)
+        .await
+        .unwrap();
+
+    let result_json: serde_json::Value = result.try_into_json().await.unwrap();
+    let time = result_json["time"].as_object().unwrap();
+    assert!(
+        time.contains_key("1.0.15"),
+        "recent version should be kept when caller signals wildcard-allow"
     );
 }

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -148,7 +148,16 @@ impl Rule for RuleNpm {
     #[inline(always)]
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
-            Some(min_package_age) => min_package_age.remove_new_packages(resp).await,
+            Some(min_package_age) => {
+                let policy = self.policy_evaluator.as_ref();
+                let is_allowed = move |name: &str| {
+                    policy.is_some_and(|p| {
+                        p.evaluate_package_install(&NpmPackageName::from(name))
+                            == PackagePolicyDecision::AllowSkipAgeCheck
+                    })
+                };
+                min_package_age.remove_new_packages(resp, is_allowed).await
+            }
             None => Ok(resp),
         }
     }
@@ -177,12 +186,21 @@ impl RuleNpm {
             return Ok(RequestAction::Allow(req));
         };
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision = policy_evaluator.evaluate_package_install(&package.fully_qualified_name);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow (admin-configured `@aikidosec/*`) fully bypasses
+                // downstream malware + min-age checks.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow (approval-flow) bypasses the malware check
+                // but stays subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 PackagePolicyDecision::BlockAll
@@ -197,7 +215,7 @@ impl RuleNpm {
             }
         }
 
-        if self.is_package_listed_as_malware(&package) {
+        if !bypass_malware && self.is_package_listed_as_malware(&package) {
             tracing::warn!(
                 name = %package.fully_qualified_name,
                 version = %package.version,

--- a/proxy-lib/src/http/firewall/rule/npm/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/tests.rs
@@ -1,5 +1,171 @@
 use super::*;
 
+use rama::http::Body;
+
+use crate::{
+    endpoint_protection::{EcosystemConfig, ExceptionLists},
+    http::firewall::events::BlockReason,
+    package::{
+        malware_list::{ListDataEntry, Reason},
+        released_packages_list::ReleasedPackageData,
+    },
+    utils::time::{SystemDuration, SystemTimestampMilliseconds},
+};
+
+fn ecosystem_config_with_allowed(allowed: &[&str]) -> EcosystemConfig {
+    EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: ExceptionLists {
+            allowed_packages: allowed.iter().map(|v| (*v).into()).collect(),
+            rejected_packages: Default::default(),
+        },
+    }
+}
+
+fn make_test_rule(
+    ecosystem_config: Option<&EcosystemConfig>,
+    malware: Vec<ListDataEntry>,
+    recent_releases: &[(&str, &str, u64)],
+) -> RuleNpm {
+    let now_ts = SystemTimestampMilliseconds::now();
+    let released_entries = recent_releases
+        .iter()
+        .map(|(name, version, hours_ago)| ReleasedPackageData {
+            package_name: (*name).to_owned(),
+            version: version.parse().unwrap(),
+            released_on: now_ts - SystemDuration::hours(*hours_ago as u16),
+        })
+        .collect();
+
+    RuleNpm {
+        target_domains: ["registry.npmjs.org"].into_iter().collect(),
+        remote_malware_list: NpmRemoteMalwareList::from_entries_for_tests(malware),
+        remote_released_packages_list: NpmRemoteReleasedPackagesList::from_entries_for_tests(
+            released_entries,
+            now_ts,
+        ),
+        maybe_min_package_age: None,
+        policy_evaluator: ecosystem_config.map(PolicyEvaluator::for_tests),
+    }
+}
+
+fn malware_entry(name: &str, version: &str) -> ListDataEntry {
+    ListDataEntry {
+        package_name: name.to_owned(),
+        version: version.parse().unwrap(),
+        reason: Reason::Malware,
+    }
+}
+
+fn tarball_request(name: &str, version: &str) -> Request {
+    let path = if let Some((_scope, bare)) = name.strip_prefix('@').and_then(|n| n.split_once('/'))
+    {
+        format!("/{name}/-/{bare}-{version}.tgz")
+    } else {
+        format!("/{name}/-/{name}-{version}.tgz")
+    };
+    Request::builder().uri(path).body(Body::empty()).unwrap()
+}
+
+fn assert_block_reason(action: RequestAction, expected: BlockReason) {
+    match action {
+        RequestAction::Block(blocked) => assert_eq!(blocked.info.block_reason, expected),
+        RequestAction::Allow(_) => panic!("expected Block({expected:?}), got Allow"),
+    }
+}
+
+fn assert_allow(action: RequestAction) {
+    if let RequestAction::Block(blocked) = action {
+        panic!("expected Allow, got Block({:?})", blocked.info.block_reason);
+    }
+}
+
+// 6-case truth table covering policy decision (AllowSkipAgeCheck / Allow / Defer)
+// crossed against downstream signals (malware list / recent release).
+
+#[tokio::test]
+async fn wildcard_allow_bypasses_malware() {
+    let cfg = ecosystem_config_with_allowed(&["@aikidosec/*"]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        vec![malware_entry("@aikidosec/ci-api-client", "1.0.15")],
+        &[],
+    );
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("@aikidosec/ci-api-client", "1.0.15"))
+        .await
+        .unwrap();
+    assert_allow(action);
+}
+
+#[tokio::test]
+async fn exact_allow_bypasses_malware() {
+    let cfg = ecosystem_config_with_allowed(&["lodash"]);
+    let rule = make_test_rule(Some(&cfg), vec![malware_entry("lodash", "4.17.21")], &[]);
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("lodash", "4.17.21"))
+        .await
+        .unwrap();
+    assert_allow(action);
+}
+
+#[tokio::test]
+async fn defer_blocks_malware() {
+    let rule = make_test_rule(None, vec![malware_entry("evil-pkg", "0.0.1")], &[]);
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("evil-pkg", "0.0.1"))
+        .await
+        .unwrap();
+    assert_block_reason(action, BlockReason::Malware);
+}
+
+#[tokio::test]
+async fn wildcard_allow_bypasses_min_age() {
+    let cfg = ecosystem_config_with_allowed(&["@aikidosec/*"]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        vec![],
+        &[("@aikidosec/ci-api-client", "1.0.15", 1)],
+    );
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("@aikidosec/ci-api-client", "1.0.15"))
+        .await
+        .unwrap();
+    assert_allow(action);
+}
+
+#[tokio::test]
+async fn exact_allow_does_not_bypass_min_age() {
+    // Approval-flow approvals (exact-match entries) bypass malware but stay
+    // subject to min-age — approving by name doesn't vouch for brand-new
+    // versions of that name.
+    let cfg = ecosystem_config_with_allowed(&["lodash"]);
+    let rule = make_test_rule(Some(&cfg), vec![], &[("lodash", "4.17.21", 1)]);
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("lodash", "4.17.21"))
+        .await
+        .unwrap();
+    assert_block_reason(action, BlockReason::NewPackage);
+}
+
+#[tokio::test]
+async fn defer_blocks_recent_release() {
+    let rule = make_test_rule(None, vec![], &[("brand-new-pkg", "0.1.0", 1)]);
+
+    let action = rule
+        .evaluate_tarball_request(tarball_request("brand-new-pkg", "0.1.0"))
+        .await
+        .unwrap();
+    assert_block_reason(action, BlockReason::NewPackage);
+}
+
 #[tokio::test]
 async fn test_parse_npm_package_from_path() {
     for (path, expected) in [

--- a/proxy-lib/src/http/firewall/rule/nuget/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/nuget/mod.rs
@@ -133,13 +133,21 @@ impl Rule for RuleNuget {
             "Nuget package download request"
         );
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision =
                 policy_evaluator.evaluate_package_install(&nuget_package.fully_qualified_name);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 PackagePolicyDecision::BlockAll
@@ -154,7 +162,7 @@ impl Rule for RuleNuget {
             }
         }
 
-        if self.is_package_listed_as_malware(&nuget_package) {
+        if !bypass_malware && self.is_package_listed_as_malware(&nuget_package) {
             return Ok(RequestAction::Block(BlockedRequest::blocked(
                 req,
                 nuget_package.into_blocked_artifact(),

--- a/proxy-lib/src/http/firewall/rule/open_vsx/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/open_vsx/mod.rs
@@ -137,12 +137,20 @@ impl Rule for RuleOpenVsx {
             "Open VSX install asset request"
         );
 
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision = policy_evaluator.evaluate_package_install(&extension.extension_id);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => (),
                 PackagePolicyDecision::BlockAll
@@ -157,7 +165,7 @@ impl Rule for RuleOpenVsx {
             }
         }
 
-        if self.is_package_listed_as_malware(&extension) {
+        if !bypass_malware && self.is_package_listed_as_malware(&extension) {
             tracing::warn!(
                 http.url.path = %path,
                 package = %extension,

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use rama::{
     Service,
     error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    extensions::ExtensionsRef as _,
     graceful::ShutdownGuard,
     http::{Request, Response, Uri},
     net::address::Domain,
@@ -14,10 +15,13 @@ use crate::{
     endpoint_protection::{
         EcosystemKey, PackagePolicyDecision, PolicyEvaluator, RemoteEndpointConfig,
     },
-    http::firewall::{
-        domain_matcher::DomainMatcher,
-        events::{Artifact, BlockReason},
-        notifier::EventNotifier,
+    http::{
+        RequestMetaUri,
+        firewall::{
+            domain_matcher::DomainMatcher,
+            events::{Artifact, BlockReason},
+            notifier::EventNotifier,
+        },
     },
     package::{
         malware_list::RemoteMalwareList, name_formatter::LowerCasePackageName,
@@ -164,12 +168,20 @@ impl Rule for RulePyPI {
         }
 
         // Apply endpoint policy (rejected packages, allow exceptions, block_all_installs).
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision = policy_evaluator.evaluate_package_install(&package_info.name);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 decision @ (PackagePolicyDecision::BlockAll
@@ -184,7 +196,7 @@ impl Rule for RulePyPI {
             }
         }
 
-        if self.is_blocked(&package_info)? {
+        if !bypass_malware && self.is_blocked(&package_info)? {
             tracing::debug!(package = %package_info.name, version = ?package_info.version, "blocked PyPI package download");
             return Ok(RequestAction::Block(BlockedRequest::blocked(
                 req,
@@ -228,6 +240,9 @@ impl Rule for RulePyPI {
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
+                if self.is_request_for_allowlisted_package(&resp) {
+                    return Ok(resp);
+                }
                 min_package_age
                     .remove_new_packages(
                         resp,
@@ -238,6 +253,31 @@ impl Rule for RulePyPI {
             }
             None => Ok(resp),
         }
+    }
+}
+
+impl RulePyPI {
+    fn is_request_for_allowlisted_package(&self, resp: &Response) -> bool {
+        let Some(policy) = self.policy_evaluator.as_ref() else {
+            return false;
+        };
+        let Some(package_info) = resp
+            .extensions()
+            .get_ref::<RequestMetaUri>()
+            .and_then(|RequestMetaUri(uri)| parse_package_info_from_path(uri.path()))
+        else {
+            return false;
+        };
+        if policy.evaluate_package_install(&package_info.name)
+            == PackagePolicyDecision::AllowSkipAgeCheck
+        {
+            tracing::debug!(
+                package = %package_info.name,
+                "PyPI metadata response: package is wildcard-allowlisted, skipping min-age strip"
+            );
+            return true;
+        }
+        false
     }
 }
 

--- a/proxy-lib/src/http/firewall/rule/pypi/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/tests.rs
@@ -1,10 +1,77 @@
-use crate::package::version::{PackageVersion, PragmaticSemver};
+use rama::{
+    extensions::Extensions as RamaExtensions,
+    http::{Body, BodyExtractExt as _, Response, Uri},
+};
 
+use crate::{
+    endpoint_protection::{EcosystemConfig, ExceptionLists, PolicyEvaluator},
+    http::RequestMetaUri,
+    package::{
+        malware_list::RemoteMalwareList,
+        released_packages_list::{ReleasedPackageData, RemoteReleasedPackagesList},
+        version::{PackageVersion, PragmaticSemver},
+    },
+    utils::time::{SystemDuration, SystemTimestampMilliseconds},
+};
+
+use super::*;
 use super::parser::{
     PackageInfo, normalize_package_name, parse_package_info_from_filename,
     parse_package_info_from_path, parse_package_info_from_url, parse_source_dist_filename,
     parse_wheel_filename,
 };
+
+fn ecosystem_config_with_allowed(allowed: &[&str]) -> EcosystemConfig {
+    EcosystemConfig {
+        block_all_installs: false,
+        request_installs: false,
+        minimum_allowed_age_timestamp: None,
+        exceptions: ExceptionLists {
+            allowed_packages: allowed.iter().map(|v| (*v).into()).collect(),
+            rejected_packages: Default::default(),
+        },
+    }
+}
+
+fn make_test_rule(
+    ecosystem_config: Option<&EcosystemConfig>,
+    recent_releases: &[(&str, &str, u64)],
+) -> RulePyPI {
+    let now_ts = SystemTimestampMilliseconds::now();
+    let released_entries = recent_releases
+        .iter()
+        .map(|(name, version, hours_ago)| ReleasedPackageData {
+            package_name: (*name).to_owned(),
+            version: version.parse().unwrap(),
+            released_on: now_ts - SystemDuration::hours(*hours_ago as u16),
+        })
+        .collect();
+
+    RulePyPI {
+        target_domains: ["pypi.org", "files.pythonhosted.org", "pypi.python.org"]
+            .into_iter()
+            .collect(),
+        remote_malware_list: RemoteMalwareList::from_entries_for_tests(vec![]),
+        remote_released_packages_list: RemoteReleasedPackagesList::from_entries_for_tests(
+            released_entries,
+            now_ts,
+        ),
+        maybe_min_package_age: Some(MinPackageAgePyPI::new(None)),
+        policy_evaluator: ecosystem_config.map(PolicyEvaluator::for_tests),
+    }
+}
+
+fn make_metadata_response(body: &str, path: &str) -> Response {
+    let resp = Response::builder()
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_owned()))
+        .unwrap();
+    let (mut parts, body) = resp.into_parts();
+    let extensions = RamaExtensions::new();
+    extensions.insert(RequestMetaUri(path.parse::<Uri>().unwrap()));
+    parts.extensions = extensions;
+    Response::from_parts(parts, body)
+}
 
 #[test]
 fn test_parse_wheel_filename() {
@@ -258,6 +325,35 @@ fn test_normalize_package_name() {
             input
         );
     }
+}
+
+#[tokio::test]
+async fn wildcard_allowlisted_metadata_skips_min_age_rewrite() {
+    let cfg = ecosystem_config_with_allowed(&["my-*"]);
+    let rule = make_test_rule(Some(&cfg), &[("my-package", "2.0.0", 1), ("my-package", "1.0.0", 72)]);
+    let body = serde_json::json!({
+        "info": {"name": "my-package", "version": "2.0.0"},
+        "releases": {
+            "1.0.0": [{"filename": "my_package-1.0.0.tar.gz"}],
+            "2.0.0": [{"filename": "my_package-2.0.0.tar.gz"}]
+        },
+        "urls": [{"filename": "my_package-2.0.0.tar.gz"}]
+    })
+    .to_string();
+
+    let result = rule
+        .evaluate_response(make_metadata_response(&body, "/pypi/my-package/json"))
+        .await
+        .unwrap();
+    let json: serde_json::Value = result.try_into_json().await.unwrap();
+
+    assert_eq!(json["info"]["version"], "2.0.0");
+    assert!(json["releases"]["1.0.0"].is_array());
+    assert!(json["releases"]["2.0.0"].is_array());
+    assert_eq!(
+        json["urls"],
+        serde_json::json!([{ "filename": "my_package-2.0.0.tar.gz" }])
+    );
 }
 
 #[test]

--- a/proxy-lib/src/http/firewall/rule/pypi/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/tests.rs
@@ -14,12 +14,12 @@ use crate::{
     utils::time::{SystemDuration, SystemTimestampMilliseconds},
 };
 
-use super::*;
 use super::parser::{
     PackageInfo, normalize_package_name, parse_package_info_from_filename,
     parse_package_info_from_path, parse_package_info_from_url, parse_source_dist_filename,
     parse_wheel_filename,
 };
+use super::*;
 
 fn ecosystem_config_with_allowed(allowed: &[&str]) -> EcosystemConfig {
     EcosystemConfig {
@@ -330,7 +330,10 @@ fn test_normalize_package_name() {
 #[tokio::test]
 async fn wildcard_allowlisted_metadata_skips_min_age_rewrite() {
     let cfg = ecosystem_config_with_allowed(&["my-*"]);
-    let rule = make_test_rule(Some(&cfg), &[("my-package", "2.0.0", 1), ("my-package", "1.0.0", 72)]);
+    let rule = make_test_rule(
+        Some(&cfg),
+        &[("my-package", "2.0.0", 1), ("my-package", "1.0.0", 72)],
+    );
     let body = serde_json::json!({
         "info": {"name": "my-package", "version": "2.0.0"},
         "releases": {

--- a/proxy-lib/src/http/firewall/rule/vscode/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/min_package_age/mod.rs
@@ -36,6 +36,7 @@ impl MinPackageAgeVSCode {
         &self,
         resp: Response,
         cutoff_ts: SystemTimestampMilliseconds,
+        is_allowed: impl Fn(&str) -> bool,
     ) -> Result<Response, BoxError> {
         if resp
             .headers()
@@ -58,7 +59,7 @@ impl MinPackageAgeVSCode {
             return Ok(Response::from_parts(parts, Body::from(bytes)));
         }
 
-        let Some(rewrite) = rewrite_json(&bytes, cutoff_ts) else {
+        let Some(rewrite) = rewrite_json(&bytes, cutoff_ts, &is_allowed) else {
             return Ok(Response::from_parts(parts, Body::from(bytes)));
         };
 
@@ -127,7 +128,11 @@ struct RewriteResult {
 /// }
 /// ```
 /// Given a `cutoff_ts` in the past, `0.4.0` is stripped and `0.3.0` is kept.
-fn rewrite_json(bytes: &[u8], cutoff_ts: SystemTimestampMilliseconds) -> Option<RewriteResult> {
+fn rewrite_json(
+    bytes: &[u8],
+    cutoff_ts: SystemTimestampMilliseconds,
+    is_allowed: &dyn Fn(&str) -> bool,
+) -> Option<RewriteResult> {
     let mut json: serde_json::Value = match serde_json::from_slice(bytes) {
         Ok(v) => v,
         Err(err) => {
@@ -155,10 +160,10 @@ fn rewrite_json(bytes: &[u8], cutoff_ts: SystemTimestampMilliseconds) -> Option<
 
     if let Some(extensions) = batch_extensions {
         for extension in extensions {
-            filter_extension_versions(extension, cutoff_ts, &mut suppressed);
+            filter_extension_versions(extension, cutoff_ts, &mut suppressed, is_allowed);
         }
     } else {
-        filter_extension_versions(&mut json, cutoff_ts, &mut suppressed);
+        filter_extension_versions(&mut json, cutoff_ts, &mut suppressed, is_allowed);
     }
 
     if suppressed.is_empty() {
@@ -183,6 +188,7 @@ fn filter_extension_versions(
     extension: &mut serde_json::Value,
     cutoff_ts: SystemTimestampMilliseconds,
     suppressed: &mut Vec<(ArcStr, PackageVersion)>,
+    is_allowed: &dyn Fn(&str) -> bool,
 ) {
     let publisher_name = extension
         .get("publisher")
@@ -202,6 +208,14 @@ fn filter_extension_versions(
     }
 
     let extension_id: ArcStr = format!("{publisher_name}.{extension_name}").into();
+
+    if is_allowed(&extension_id) {
+        tracing::debug!(
+            extension = %extension_id,
+            "VSCode marketplace metadata: extension is allowlisted, skipping min-age strip"
+        );
+        return;
+    }
 
     let Some(versions) = extension.get_mut("versions").and_then(|v| v.as_array_mut()) else {
         return;

--- a/proxy-lib/src/http/firewall/rule/vscode/min_package_age/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/min_package_age/tests.rs
@@ -61,7 +61,7 @@ async fn single_removes_version_newer_than_cutoff() {
     let resp = make_single_extension_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -80,7 +80,7 @@ async fn single_keeps_version_older_than_cutoff() {
     let resp = make_single_extension_response("pub", "ext", &[("1.0.0", &old)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -100,7 +100,7 @@ async fn single_removes_all_versions_when_all_too_new() {
         make_single_extension_response("pub", "ext", &[("1.0.0", &recent), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -119,7 +119,7 @@ async fn batch_removes_version_newer_than_cutoff() {
     let resp = make_extensionquery_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -138,7 +138,7 @@ async fn batch_keeps_version_older_than_cutoff() {
     let resp = make_extensionquery_response("pub", "ext", &[("1.0.0", &old)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -167,7 +167,7 @@ async fn strips_cache_headers_when_response_is_rewritten() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     assert!(
@@ -194,7 +194,7 @@ async fn preserves_cache_headers_when_nothing_removed() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     assert_eq!(result.headers().get("etag").unwrap(), "abc123");
@@ -214,7 +214,7 @@ async fn passthrough_invalid_json() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let body = result.try_into_string().await.unwrap();
@@ -229,9 +229,59 @@ async fn passthrough_non_json_content_type() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let body = result.try_into_string().await.unwrap();
     assert_eq!(body, "plain text");
+}
+
+#[tokio::test]
+async fn allowlisted_extension_is_not_rewritten() {
+    let recent = timestamp_hours_ago(1);
+    let old = timestamp_hours_ago(50);
+    let resp = make_single_extension_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
+    let min_package_age = MinPackageAgeVSCode::new(None);
+    let is_allowed = |id: &str| id == "pub.ext";
+    let result = min_package_age
+        .remove_new_versions(resp, cutoff_secs_ago(24), is_allowed)
+        .await
+        .unwrap();
+    let json: serde_json::Value = result.try_into_json().await.unwrap();
+    let versions: Vec<&str> = json["versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        versions,
+        ["1.0.0", "1.0.1"],
+        "allowlisted extension should keep all versions"
+    );
+}
+
+#[tokio::test]
+async fn allowlisted_extension_in_batch_is_not_rewritten() {
+    let recent = timestamp_hours_ago(1);
+    let old = timestamp_hours_ago(50);
+    let resp = make_extensionquery_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
+    let min_package_age = MinPackageAgeVSCode::new(None);
+    let is_allowed = |id: &str| id == "pub.ext";
+    let result = min_package_age
+        .remove_new_versions(resp, cutoff_secs_ago(24), is_allowed)
+        .await
+        .unwrap();
+    let json: serde_json::Value = result.try_into_json().await.unwrap();
+    let versions: Vec<&str> = json["results"][0]["extensions"][0]["versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        versions,
+        ["1.0.0", "1.0.1"],
+        "allowlisted extension should keep all versions in batch responses too"
+    );
 }

--- a/proxy-lib/src/http/firewall/rule/vscode/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/mod.rs
@@ -156,13 +156,21 @@ impl Rule for RuleVSCode {
         );
 
         // Apply endpoint policy (rejected packages, allow exceptions, block_all_installs).
+        let mut bypass_malware = false;
+
         if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
             let decision =
                 policy_evaluator.evaluate_package_install(&vscode_extension.extension_id);
 
             match decision {
-                PackagePolicyDecision::Allow => {
+                // Wildcard allow fully bypasses downstream malware + min-age.
+                PackagePolicyDecision::AllowSkipAgeCheck => {
                     return Ok(RequestAction::Allow(req));
+                }
+                // Exact-match allow bypasses the malware check but stays
+                // subject to min-age below.
+                PackagePolicyDecision::Allow => {
+                    bypass_malware = true;
                 }
                 PackagePolicyDecision::Defer => {}
                 PackagePolicyDecision::BlockAll
@@ -177,7 +185,7 @@ impl Rule for RuleVSCode {
             }
         }
 
-        if self.is_package_listed_as_malware(&vscode_extension) {
+        if !bypass_malware && self.is_package_listed_as_malware(&vscode_extension) {
             tracing::info!(
                 http.url.path = %path,
                 package = %vscode_extension,
@@ -245,8 +253,16 @@ impl Rule for RuleVSCode {
             return Ok(resp);
         };
 
+        let policy = self.policy_evaluator.as_ref();
+        let is_allowed = move |extension_id: &str| {
+            policy.is_some_and(|p| {
+                p.evaluate_package_install(&new_vscode_package_name(extension_id))
+                    == PackagePolicyDecision::AllowSkipAgeCheck
+            })
+        };
+
         min_package_age
-            .remove_new_versions(resp, self.get_package_age_cutoff_ts())
+            .remove_new_versions(resp, self.get_package_age_cutoff_ts(), is_allowed)
             .await
     }
 }

--- a/proxy-lib/src/package/malware_list.rs
+++ b/proxy-lib/src/package/malware_list.rs
@@ -154,6 +154,21 @@ where
     }
 }
 
+#[cfg(test)]
+impl<K> RemoteMalwareList<K>
+where
+    K: PackageName + radix_trie::TrieKey,
+{
+    /// Test constructor: build a [`RemoteMalwareList`] in-memory from a list of
+    /// raw entries, bypassing the HTTP fetch path.
+    pub(crate) fn from_entries_for_tests(entries: Vec<ListDataEntry>) -> Self {
+        let trie = trie_from_malware_list::<K>(entries);
+        Self {
+            trie: RemoteResource::from_state(trie),
+        }
+    }
+}
+
 rama::utils::macros::enums::enum_builder! {
     @String
     pub enum Reason {

--- a/proxy-lib/src/package/name_formatter/glob_set.rs
+++ b/proxy-lib/src/package/name_formatter/glob_set.rs
@@ -89,6 +89,22 @@ impl<K: PackageName + Hash> GlobSet<K> {
         self.match_package_name_ref(package_name.as_ref())
     }
 
+    /// Like [`Self::match_package_name`], but skips the exact-match set — only returns
+    /// `true` when the name matches via a wildcard pattern. Used by callers that
+    /// want to distinguish admin-configured wildcards (e.g. `@aikidosec/*`) from
+    /// approval-flow exact-match entries.
+    #[inline(always)]
+    pub fn match_wildcard_only(&self, package_name: &K) -> bool {
+        self.match_package_name_ref(package_name.as_ref())
+    }
+
+    /// Returns `true` only when `package_name` is in the exact-match set.
+    /// Wildcard patterns are not consulted.
+    #[inline(always)]
+    pub fn match_exact_only(&self, package_name: &K) -> bool {
+        self.exact.contains(package_name)
+    }
+
     pub fn match_package_name_ref<'a>(&'a self, package_name: K::Ref<'a>) -> bool
     where
         K: 'a,

--- a/proxy-lib/src/package/name_formatter/glob_set_tests.rs
+++ b/proxy-lib/src/package/name_formatter/glob_set_tests.rs
@@ -177,3 +177,82 @@ fn empty_pattern_matches_only_empty_name() {
     assert!(set.match_package_name(&name("")));
     assert!(!set.match_package_name(&name("x")));
 }
+
+#[test]
+fn match_wildcard_only_skips_exact_set() {
+    let set = lower_set(&["@aikidosec/*", "requests"]);
+
+    // wildcard pattern: matches via the trie
+    assert!(set.match_wildcard_only(&name("@aikidosec/ci-api-client")));
+    // exact pattern: must NOT count as a wildcard match
+    assert!(!set.match_wildcard_only(&name("requests")));
+    // unrelated name: no match
+    assert!(!set.match_wildcard_only(&name("numpy")));
+
+    // sanity: the regular matcher still treats both as allowed
+    assert!(set.match_package_name(&name("@aikidosec/ci-api-client")));
+    assert!(set.match_package_name(&name("requests")));
+}
+
+#[test]
+fn match_wildcard_only_treats_any_star_position_as_wildcard() {
+    // Any pattern containing `*` (anywhere) is compiled into the trie, so
+    // `match_wildcard_only` returns true regardless of star position.
+    let set = lower_set(&["trail*", "*lead", "mid*dle", "*"]);
+
+    assert!(set.match_wildcard_only(&name("trail-anything")));
+    assert!(set.match_wildcard_only(&name("anythinglead")));
+    assert!(set.match_wildcard_only(&name("midXdle")));
+    // `*` alone matches everything via wildcard_terminal at the root.
+    assert!(set.match_wildcard_only(&name("totally-unrelated")));
+}
+
+#[test]
+fn match_exact_only_ignores_wildcards() {
+    // `match_exact_only` consults only the exact-match HashSet — wildcard
+    // patterns must never satisfy it, even when the name happens to fall
+    // within a wildcard's reach.
+    let set = lower_set(&["requests", "trail*", "*lead", "mid*dle"]);
+
+    assert!(set.match_exact_only(&name("requests")));
+    assert!(!set.match_exact_only(&name("trail-anything")));
+    assert!(!set.match_exact_only(&name("anythinglead")));
+    assert!(!set.match_exact_only(&name("midXdle")));
+    assert!(!set.match_exact_only(&name("numpy")));
+}
+
+#[test]
+fn wildcard_and_exact_matchers_are_disjoint_per_entry() {
+    // For any single pattern the two predicates partition match results:
+    // an exact pattern only fires `match_exact_only`, a wildcard pattern
+    // only fires `match_wildcard_only`. The pair never both return true
+    // for the same (set, name).
+    let cases = [
+        // (pattern, matching_name, is_wildcard)
+        ("requests", "requests", false),
+        ("@aikidosec/*", "@aikidosec/ci-api-client", true),
+        ("*-test", "pkg-test", true),
+        ("pkg-*-evil", "pkg-x-evil", true),
+        ("*", "anything", true),
+    ];
+
+    for (pattern, matching_name, is_wildcard) in cases {
+        let set = lower_set(&[pattern]);
+        let n = name(matching_name);
+
+        assert!(
+            set.match_package_name(&n),
+            "pattern={pattern:?} should match {matching_name:?}"
+        );
+        assert_eq!(
+            set.match_wildcard_only(&n),
+            is_wildcard,
+            "pattern={pattern:?} match_wildcard_only mismatch"
+        );
+        assert_eq!(
+            set.match_exact_only(&n),
+            !is_wildcard,
+            "pattern={pattern:?} match_exact_only mismatch"
+        );
+    }
+}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added AllowSkipAgeCheck decision to bypass min-age checks
* Adjusted policy evaluation to distinguish wildcard and exact allows
* Updated firewall rules to respect wildcard allow bypasses malware/min-age
* Extended min-age rewrite functions to accept is_allowed predicate
* Added and adapted tests to cover wildcard/ exact allow semantics


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110076399?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->