### PR TITLE
Check policy before version rewrites

### DIFF
--- a/proxy-lib/src/http/firewall/rule/golang/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/golang/mod.rs
@@ -149,6 +149,18 @@ impl Rule for RuleGolang {
         else {
             return Ok(resp);
         };
+
+        if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
+            let name = GolangPackageName::from(module_name.as_str());
+            if policy_evaluator.evaluate_package_install(&name) == PackagePolicyDecision::Allow {
+                tracing::debug!(
+                    module = %module_name,
+                    "Go module list: module is allowlisted, skipping min-age strip"
+                );
+                return Ok(resp);
+            }
+        }
+
         min_package_age
             .rewrite_list_response(
                 resp,

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/mod.rs
@@ -55,7 +55,11 @@ impl MinPackageAge {
         req.headers_mut().typed_insert(Accept::json());
     }
 
-    pub(super) async fn remove_new_packages(&self, resp: Response) -> Result<Response, BoxError> {
+    pub(super) async fn remove_new_packages(
+        &self,
+        resp: Response,
+        is_allowed: impl Fn(&str) -> bool,
+    ) -> Result<Response, BoxError> {
         if resp
             .headers()
             .typed_get::<ContentType>()
@@ -84,17 +88,25 @@ impl MinPackageAge {
             }
         };
 
-        let versions_to_remove = Self::get_versions_to_remove(&json, cutoff);
-
-        if versions_to_remove.is_empty() {
-            return Ok(Response::from_parts(parts, Body::from(bytes)));
-        }
-
         let package_name: ArcStr = json
             .get("name")
             .and_then(|n| n.as_str())
             .unwrap_or("unknown package")
             .into();
+
+        if is_allowed(&package_name) {
+            tracing::debug!(
+                package = %package_name,
+                "npm metadata response: package is allowlisted, skipping min-age strip"
+            );
+            return Ok(Response::from_parts(parts, Body::from(bytes)));
+        }
+
+        let versions_to_remove = Self::get_versions_to_remove(&json, cutoff);
+
+        if versions_to_remove.is_empty() {
+            return Ok(Response::from_parts(parts, Body::from(bytes)));
+        }
 
         for key in versions_to_remove.iter() {
             json = Self::remove_version_from_json(json, key);

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
@@ -65,7 +65,10 @@ async fn removes_versions_newer_than_48h() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("created"));
@@ -83,7 +86,10 @@ async fn keeps_versions_older_than_48h() {
     let body = format!(r#"{{"time":{{"created":"2020-01-01T00:00:00.000Z","1.0.0":"{old}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("1.0.0"), "old version should be kept");
@@ -95,7 +101,10 @@ async fn keeps_created_and_modified_always() {
     let body = format!(r#"{{"time":{{"created":"{recent}","modified":"{recent}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(
@@ -115,7 +124,10 @@ async fn passthrough_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     assert_eq!(
         result.headers().get("content-type").unwrap(),
         "application/octet-stream"
@@ -126,7 +138,10 @@ async fn passthrough_non_json_response() {
 async fn passthrough_invalid_json_body() {
     let resp = make_json_response("not valid json {{{");
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let body_str = result.try_into_string().await.unwrap();
     assert_eq!(body_str, "not valid json {{{");
 }
@@ -140,7 +155,10 @@ async fn updates_latest_tag_when_latest_is_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -155,7 +173,10 @@ async fn updates_latest_to_most_recent_stable_version() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.1");
 }
@@ -168,7 +189,10 @@ async fn removes_latest_tag_when_no_stable_versions_remain() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -189,7 +213,10 @@ async fn preserves_latest_tag_when_latest_is_not_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -203,7 +230,10 @@ async fn excludes_prerelease_versions_from_latest_tag() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -223,7 +253,10 @@ async fn no_dist_tags_is_unchanged() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json.as_object().unwrap().get("dist-tags").is_none(),
@@ -246,7 +279,10 @@ async fn removes_response_caching() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
 
     assert!(
         result.headers().get("last-modified").is_none(),
@@ -271,7 +307,10 @@ async fn does_not_strip_headers_for_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
     assert_eq!(
         result.headers().get("etag").unwrap(),
         r#""abc123""#,
@@ -294,7 +333,10 @@ async fn does_not_strip_cache_headers_when_json_is_not_modified() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
+    let result = min_package_age
+        .remove_new_packages(resp, |_| false)
+        .await
+        .unwrap();
 
     assert_eq!(
         result.headers().get("etag").unwrap(),

--- a/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/min_package_age/tests.rs
@@ -65,7 +65,7 @@ async fn removes_versions_newer_than_48h() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("created"));
@@ -83,7 +83,7 @@ async fn keeps_versions_older_than_48h() {
     let body = format!(r#"{{"time":{{"created":"2020-01-01T00:00:00.000Z","1.0.0":"{old}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(time.contains_key("1.0.0"), "old version should be kept");
@@ -95,7 +95,7 @@ async fn keeps_created_and_modified_always() {
     let body = format!(r#"{{"time":{{"created":"{recent}","modified":"{recent}"}}}}"#);
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     let time = result_json["time"].as_object().unwrap();
     assert!(
@@ -115,7 +115,7 @@ async fn passthrough_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     assert_eq!(
         result.headers().get("content-type").unwrap(),
         "application/octet-stream"
@@ -126,7 +126,7 @@ async fn passthrough_non_json_response() {
 async fn passthrough_invalid_json_body() {
     let resp = make_json_response("not valid json {{{");
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let body_str = result.try_into_string().await.unwrap();
     assert_eq!(body_str, "not valid json {{{");
 }
@@ -140,7 +140,7 @@ async fn updates_latest_tag_when_latest_is_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -155,7 +155,7 @@ async fn updates_latest_to_most_recent_stable_version() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.1");
 }
@@ -168,7 +168,7 @@ async fn removes_latest_tag_when_no_stable_versions_remain() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -189,7 +189,7 @@ async fn preserves_latest_tag_when_latest_is_not_removed() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert_eq!(result_json["dist-tags"]["latest"], "1.0.0");
 }
@@ -203,7 +203,7 @@ async fn excludes_prerelease_versions_from_latest_tag() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json["dist-tags"]
@@ -223,7 +223,7 @@ async fn no_dist_tags_is_unchanged() {
     );
     let resp = make_json_response(&body);
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     let result_json: serde_json::Value = result.try_into_json().await.unwrap();
     assert!(
         result_json.as_object().unwrap().get("dist-tags").is_none(),
@@ -246,7 +246,7 @@ async fn removes_response_caching() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
 
     assert!(
         result.headers().get("last-modified").is_none(),
@@ -271,7 +271,7 @@ async fn does_not_strip_headers_for_non_json_response() {
         .body(Body::from("binary data"))
         .unwrap();
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
     assert_eq!(
         result.headers().get("etag").unwrap(),
         r#""abc123""#,
@@ -294,7 +294,7 @@ async fn does_not_strip_cache_headers_when_json_is_not_modified() {
         .unwrap();
 
     let min_package_age = MinPackageAge::new(None, None);
-    let result = min_package_age.remove_new_packages(resp).await.unwrap();
+    let result = min_package_age.remove_new_packages(resp, |_| false).await.unwrap();
 
     assert_eq!(
         result.headers().get("etag").unwrap(),
@@ -310,5 +310,32 @@ async fn does_not_strip_cache_headers_when_json_is_not_modified() {
         result.headers().get("cache-control").unwrap(),
         "max-age=3600",
         "existing cache-control should still be there"
+    );
+}
+
+#[tokio::test]
+async fn allowlisted_package_is_not_rewritten() {
+    // When the caller's `is_allowed` closure returns true (caller will return true
+    // when the policy returns Allow for the package), the response is served
+    // verbatim — recent versions stay in `time` and `dist-tags.latest` is untouched.
+    let recent = timestamp_hours_ago(1);
+    let body = format!(
+        r#"{{"name":"@aikidosec/ci-api-client","dist-tags":{{"latest":"1.0.15"}},"time":{{"created":"2020-01-01T00:00:00.000Z","1.0.0":"2020-01-01T00:00:00.000Z","1.0.15":"{recent}"}}}}"#
+    );
+    let resp = make_json_response(&body);
+    let min_package_age = MinPackageAge::new(None, None);
+    let result = min_package_age
+        .remove_new_packages(resp, |name| name == "@aikidosec/ci-api-client")
+        .await
+        .unwrap();
+    let result_json: serde_json::Value = result.try_into_json().await.unwrap();
+    let time = result_json["time"].as_object().unwrap();
+    assert!(
+        time.contains_key("1.0.15"),
+        "recent version should be preserved when allowlisted"
+    );
+    assert_eq!(
+        result_json["dist-tags"]["latest"], "1.0.15",
+        "latest dist-tag should be untouched"
     );
 }

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -150,6 +150,8 @@ impl Rule for RuleNpm {
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
                 min_package_age
+                    // Parsing package names out of registry metadata belongs in the rewriter.
+                    // The allowlist policy decision does not; that business logic belongs here.
                     .remove_new_packages(resp, |name| {
                         self.is_package_allowlisted(&NpmPackageName::from(name))
                     })

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -149,14 +149,11 @@ impl Rule for RuleNpm {
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
-                let policy = self.policy_evaluator.as_ref();
-                let is_allowed = move |name: &str| {
-                    policy.is_some_and(|p| {
-                        p.evaluate_package_install(&NpmPackageName::from(name))
-                            == PackagePolicyDecision::Allow
+                min_package_age
+                    .remove_new_packages(resp, |name| {
+                        self.is_package_allowlisted(&NpmPackageName::from(name))
                     })
-                };
-                min_package_age.remove_new_packages(resp, is_allowed).await
+                    .await
             }
             None => Ok(resp),
         }
@@ -165,6 +162,16 @@ impl Rule for RuleNpm {
 
 impl RuleNpm {
     const DEFAULT_MIN_PACKAGE_AGE: SystemDuration = SystemDuration::days(2);
+
+    /// Returns `true` if the endpoint-protection policy explicitly allowlists
+    /// the given npm package name (i.e. evaluates to [`PackagePolicyDecision::Allow`]).
+    /// Used by the metadata-rewrite path to skip the min-age strip for trusted
+    /// packages.
+    fn is_package_allowlisted(&self, name: &NpmPackageName) -> bool {
+        self.policy_evaluator.as_ref().is_some_and(|policy| {
+            policy.evaluate_package_install(name) == PackagePolicyDecision::Allow
+        })
+    }
 
     fn get_package_age_cutoff_ts(&self) -> SystemTimestampMilliseconds {
         self.policy_evaluator

--- a/proxy-lib/src/http/firewall/rule/npm/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/npm/mod.rs
@@ -148,7 +148,16 @@ impl Rule for RuleNpm {
     #[inline(always)]
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
         match &self.maybe_min_package_age {
-            Some(min_package_age) => min_package_age.remove_new_packages(resp).await,
+            Some(min_package_age) => {
+                let policy = self.policy_evaluator.as_ref();
+                let is_allowed = move |name: &str| {
+                    policy.is_some_and(|p| {
+                        p.evaluate_package_install(&NpmPackageName::from(name))
+                            == PackagePolicyDecision::Allow
+                    })
+                };
+                min_package_age.remove_new_packages(resp, is_allowed).await
+            }
             None => Ok(resp),
         }
     }

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use rama::{
     Service,
     error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    extensions::ExtensionsRef as _,
     graceful::ShutdownGuard,
     http::{Request, Response, Uri},
     net::address::Domain,
@@ -14,10 +15,13 @@ use crate::{
     endpoint_protection::{
         EcosystemKey, PackagePolicyDecision, PolicyEvaluator, RemoteEndpointConfig,
     },
-    http::firewall::{
-        domain_matcher::DomainMatcher,
-        events::{Artifact, BlockReason},
-        notifier::EventNotifier,
+    http::{
+        RequestMetaUri,
+        firewall::{
+            domain_matcher::DomainMatcher,
+            events::{Artifact, BlockReason},
+            notifier::EventNotifier,
+        },
     },
     package::{
         malware_list::RemoteMalwareList, name_formatter::LowerCasePackageName,
@@ -226,18 +230,35 @@ impl Rule for RulePyPI {
 
     #[inline(always)]
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
-        match &self.maybe_min_package_age {
-            Some(min_package_age) => {
-                min_package_age
-                    .remove_new_packages(
-                        resp,
-                        &self.remote_released_packages_list,
-                        self.get_package_age_cutoff_ts(),
-                    )
-                    .await
+        let Some(min_package_age) = &self.maybe_min_package_age else {
+            return Ok(resp);
+        };
+
+        if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
+            if let Some(package_info) = resp
+                .extensions()
+                .get_ref::<RequestMetaUri>()
+                .and_then(|RequestMetaUri(uri)| parse_package_info_from_path(uri.path()))
+            {
+                if policy_evaluator.evaluate_package_install(&package_info.name)
+                    == PackagePolicyDecision::Allow
+                {
+                    tracing::debug!(
+                        package = %package_info.name,
+                        "PyPI metadata response: package is allowlisted, skipping min-age strip"
+                    );
+                    return Ok(resp);
+                }
             }
-            None => Ok(resp),
         }
+
+        min_package_age
+            .remove_new_packages(
+                resp,
+                &self.remote_released_packages_list,
+                self.get_package_age_cutoff_ts(),
+            )
+            .await
     }
 }
 

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -110,6 +110,16 @@ impl RulePyPI {
             .unwrap_or_else(|| SystemTimestampMilliseconds::now() - Self::DEFAULT_MIN_PACKAGE_AGE)
     }
 
+    /// Returns `true` if the endpoint-protection policy explicitly allowlists
+    /// the given PyPI package name (i.e. evaluates to [`PackagePolicyDecision::Allow`]).
+    /// Used by the metadata-rewrite path to skip the min-age strip for trusted
+    /// packages.
+    fn is_package_allowlisted(&self, name: &PyPIPackageName) -> bool {
+        self.policy_evaluator.as_ref().is_some_and(|policy| {
+            policy.evaluate_package_install(name) == PackagePolicyDecision::Allow
+        })
+    }
+
     fn is_blocked(&self, package_info: &PackageInfo) -> Result<bool, BoxError> {
         let entries = self.remote_malware_list.find_entries(&package_info.name);
         let Some(entries) = entries.entries() else {
@@ -234,16 +244,18 @@ impl Rule for RulePyPI {
             return Ok(resp);
         };
 
-        if let Some(policy_evaluator) = self.policy_evaluator.as_ref()
-            && let Some(package_info) = resp
-                .extensions()
-                .get_ref::<RequestMetaUri>()
-                .and_then(|RequestMetaUri(uri)| parse_package_info_from_path(uri.path()))
-            && policy_evaluator.evaluate_package_install(&package_info.name)
-                == PackagePolicyDecision::Allow
-        {
+        // Resolve the metadata package name from the request URI, then keep it only
+        // if the policy explicitly allowlists it. `Some` here means "skip the strip".
+        let allowlisted_package_name = resp
+            .extensions()
+            .get_ref::<RequestMetaUri>()
+            .and_then(|RequestMetaUri(uri)| parse_package_info_from_path(uri.path()))
+            .map(|package_info| package_info.name)
+            .filter(|name| self.is_package_allowlisted(name));
+
+        if let Some(name) = allowlisted_package_name {
             tracing::debug!(
-                package = %package_info.name,
+                package = %name,
                 "PyPI metadata response: package is allowlisted, skipping min-age strip"
             );
             return Ok(resp);

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -234,22 +234,19 @@ impl Rule for RulePyPI {
             return Ok(resp);
         };
 
-        if let Some(policy_evaluator) = self.policy_evaluator.as_ref() {
-            if let Some(package_info) = resp
+        if let Some(policy_evaluator) = self.policy_evaluator.as_ref()
+            && let Some(package_info) = resp
                 .extensions()
                 .get_ref::<RequestMetaUri>()
                 .and_then(|RequestMetaUri(uri)| parse_package_info_from_path(uri.path()))
-            {
-                if policy_evaluator.evaluate_package_install(&package_info.name)
-                    == PackagePolicyDecision::Allow
-                {
-                    tracing::debug!(
-                        package = %package_info.name,
-                        "PyPI metadata response: package is allowlisted, skipping min-age strip"
-                    );
-                    return Ok(resp);
-                }
-            }
+            && policy_evaluator.evaluate_package_install(&package_info.name)
+                == PackagePolicyDecision::Allow
+        {
+            tracing::debug!(
+                package = %package_info.name,
+                "PyPI metadata response: package is allowlisted, skipping min-age strip"
+            );
+            return Ok(resp);
         }
 
         min_package_age

--- a/proxy-lib/src/http/firewall/rule/vscode/min_package_age/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/min_package_age/mod.rs
@@ -36,6 +36,7 @@ impl MinPackageAgeVSCode {
         &self,
         resp: Response,
         cutoff_ts: SystemTimestampMilliseconds,
+        is_allowed: impl Fn(&str) -> bool,
     ) -> Result<Response, BoxError> {
         if resp
             .headers()
@@ -58,7 +59,7 @@ impl MinPackageAgeVSCode {
             return Ok(Response::from_parts(parts, Body::from(bytes)));
         }
 
-        let Some(rewrite) = rewrite_json(&bytes, cutoff_ts) else {
+        let Some(rewrite) = rewrite_json(&bytes, cutoff_ts, &is_allowed) else {
             return Ok(Response::from_parts(parts, Body::from(bytes)));
         };
 
@@ -127,7 +128,11 @@ struct RewriteResult {
 /// }
 /// ```
 /// Given a `cutoff_ts` in the past, `0.4.0` is stripped and `0.3.0` is kept.
-fn rewrite_json(bytes: &[u8], cutoff_ts: SystemTimestampMilliseconds) -> Option<RewriteResult> {
+fn rewrite_json(
+    bytes: &[u8],
+    cutoff_ts: SystemTimestampMilliseconds,
+    is_allowed: &impl Fn(&str) -> bool,
+) -> Option<RewriteResult> {
     let mut json: serde_json::Value = match serde_json::from_slice(bytes) {
         Ok(v) => v,
         Err(err) => {
@@ -155,10 +160,10 @@ fn rewrite_json(bytes: &[u8], cutoff_ts: SystemTimestampMilliseconds) -> Option<
 
     if let Some(extensions) = batch_extensions {
         for extension in extensions {
-            filter_extension_versions(extension, cutoff_ts, &mut suppressed);
+            filter_extension_versions(extension, cutoff_ts, &mut suppressed, is_allowed);
         }
     } else {
-        filter_extension_versions(&mut json, cutoff_ts, &mut suppressed);
+        filter_extension_versions(&mut json, cutoff_ts, &mut suppressed, is_allowed);
     }
 
     if suppressed.is_empty() {
@@ -183,6 +188,7 @@ fn filter_extension_versions(
     extension: &mut serde_json::Value,
     cutoff_ts: SystemTimestampMilliseconds,
     suppressed: &mut Vec<(ArcStr, PackageVersion)>,
+    is_allowed: &impl Fn(&str) -> bool,
 ) {
     let publisher_name = extension
         .get("publisher")
@@ -201,7 +207,17 @@ fn filter_extension_versions(
         return;
     }
 
-    let extension_id: ArcStr = format!("{publisher_name}.{extension_name}").into();
+    let extension_id_str = format!("{publisher_name}.{extension_name}");
+
+    if is_allowed(&extension_id_str) {
+        tracing::debug!(
+            extension = %extension_id_str,
+            "VSCode metadata response: extension is allowlisted, skipping min-age strip"
+        );
+        return;
+    }
+
+    let extension_id: ArcStr = extension_id_str.into();
 
     let Some(versions) = extension.get_mut("versions").and_then(|v| v.as_array_mut()) else {
         return;

--- a/proxy-lib/src/http/firewall/rule/vscode/min_package_age/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/min_package_age/tests.rs
@@ -61,7 +61,7 @@ async fn single_removes_version_newer_than_cutoff() {
     let resp = make_single_extension_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -80,7 +80,7 @@ async fn single_keeps_version_older_than_cutoff() {
     let resp = make_single_extension_response("pub", "ext", &[("1.0.0", &old)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -100,7 +100,7 @@ async fn single_removes_all_versions_when_all_too_new() {
         make_single_extension_response("pub", "ext", &[("1.0.0", &recent), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -119,7 +119,7 @@ async fn batch_removes_version_newer_than_cutoff() {
     let resp = make_extensionquery_response("pub", "ext", &[("1.0.0", &old), ("1.0.1", &recent)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -138,7 +138,7 @@ async fn batch_keeps_version_older_than_cutoff() {
     let resp = make_extensionquery_response("pub", "ext", &[("1.0.0", &old)]);
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let json: serde_json::Value = result.try_into_json().await.unwrap();
@@ -167,7 +167,7 @@ async fn strips_cache_headers_when_response_is_rewritten() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     assert!(
@@ -194,7 +194,7 @@ async fn preserves_cache_headers_when_nothing_removed() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     assert_eq!(result.headers().get("etag").unwrap(), "abc123");
@@ -214,7 +214,7 @@ async fn passthrough_invalid_json() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let body = result.try_into_string().await.unwrap();
@@ -229,9 +229,53 @@ async fn passthrough_non_json_content_type() {
         .unwrap();
     let min_package_age = MinPackageAgeVSCode::new(None);
     let result = min_package_age
-        .remove_new_versions(resp, cutoff_secs_ago(24))
+        .remove_new_versions(resp, cutoff_secs_ago(24), |_| false)
         .await
         .unwrap();
     let body = result.try_into_string().await.unwrap();
     assert_eq!(body, "plain text");
+}
+
+// --- allowlist short-circuit (per-extension) ---
+
+#[tokio::test]
+async fn single_allowlisted_extension_is_not_filtered() {
+    // The publisher.name id is `aikido.endpoint`. When `is_allowed` returns true for
+    // it, the recent (would-be-stripped) version stays in the response.
+    let recent = timestamp_hours_ago(1);
+    let resp = make_single_extension_response("aikido", "endpoint", &[("1.0.1", &recent)]);
+    let min_package_age = MinPackageAgeVSCode::new(None);
+    let result = min_package_age
+        .remove_new_versions(resp, cutoff_secs_ago(24), |id| id == "aikido.endpoint")
+        .await
+        .unwrap();
+    let json: serde_json::Value = result.try_into_json().await.unwrap();
+    let versions: Vec<&str> = json["versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(versions, ["1.0.1"]);
+}
+
+#[tokio::test]
+async fn batch_allowlisted_extension_is_not_filtered() {
+    // Per-extension allowlist must apply inside the batch endpoint too — that's
+    // the whole point of doing the check inside `filter_extension_versions`.
+    let recent = timestamp_hours_ago(1);
+    let resp = make_extensionquery_response("aikido", "endpoint", &[("1.0.1", &recent)]);
+    let min_package_age = MinPackageAgeVSCode::new(None);
+    let result = min_package_age
+        .remove_new_versions(resp, cutoff_secs_ago(24), |id| id == "aikido.endpoint")
+        .await
+        .unwrap();
+    let json: serde_json::Value = result.try_into_json().await.unwrap();
+    let versions: Vec<&str> = json["results"][0]["extensions"][0]["versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(versions, ["1.0.1"]);
 }

--- a/proxy-lib/src/http/firewall/rule/vscode/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/mod.rs
@@ -245,8 +245,16 @@ impl Rule for RuleVSCode {
             return Ok(resp);
         };
 
+        let policy = self.policy_evaluator.as_ref();
+        let is_allowed = move |extension_id: &str| {
+            policy.is_some_and(|p| {
+                p.evaluate_package_install(&new_vscode_package_name(extension_id))
+                    == PackagePolicyDecision::Allow
+            })
+        };
+
         min_package_age
-            .remove_new_versions(resp, self.get_package_age_cutoff_ts())
+            .remove_new_versions(resp, self.get_package_age_cutoff_ts(), is_allowed)
             .await
     }
 }

--- a/proxy-lib/src/http/firewall/rule/vscode/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/mod.rs
@@ -245,22 +245,26 @@ impl Rule for RuleVSCode {
             return Ok(resp);
         };
 
-        let policy = self.policy_evaluator.as_ref();
-        let is_allowed = move |extension_id: &str| {
-            policy.is_some_and(|p| {
-                p.evaluate_package_install(&new_vscode_package_name(extension_id))
-                    == PackagePolicyDecision::Allow
-            })
-        };
-
         min_package_age
-            .remove_new_versions(resp, self.get_package_age_cutoff_ts(), is_allowed)
+            .remove_new_versions(resp, self.get_package_age_cutoff_ts(), |extension_id| {
+                self.is_extension_allowlisted(&new_vscode_package_name(extension_id))
+            })
             .await
     }
 }
 
 impl RuleVSCode {
     const DEFAULT_MIN_PACKAGE_AGE: SystemDuration = SystemDuration::days(1);
+
+    /// Returns `true` if the endpoint-protection policy explicitly allowlists
+    /// the given extension ID (`publisher.name`), i.e. evaluates to
+    /// [`PackagePolicyDecision::Allow`]. Used by the metadata-rewrite path
+    /// to skip the min-age strip for trusted extensions.
+    fn is_extension_allowlisted(&self, extension_id: &VSCodePackageName) -> bool {
+        self.policy_evaluator.as_ref().is_some_and(|policy| {
+            policy.evaluate_package_install(extension_id) == PackagePolicyDecision::Allow
+        })
+    }
 
     fn get_package_age_cutoff_ts(&self) -> SystemTimestampMilliseconds {
         self.policy_evaluator

--- a/proxy-lib/src/http/firewall/rule/vscode/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/vscode/mod.rs
@@ -246,6 +246,8 @@ impl Rule for RuleVSCode {
         };
 
         min_package_age
+            // Parsing extension IDs out of marketplace metadata belongs in the rewriter.
+            // The allowlist policy decision does not; that business logic belongs here.
             .remove_new_versions(resp, self.get_package_age_cutoff_ts(), |extension_id| {
                 self.is_extension_allowlisted(&new_vscode_package_name(extension_id))
             })


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Applied endpoint policy checks before metadata version rewrites across ecosystems
* Added is_package_allowlisted helpers and used them to skip rewrites
* Changed min-age rewrite APIs to accept allowlist predicate parameter

**🔧 Refactors**
* Updated unit tests to supply allowlist closures for rewritten responses


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110204490?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->