### PR TITLE
Chrome Extension UI Notification: wait for human readable name

### DIFF
--- a/internal/ingress/block_handler.go
+++ b/internal/ingress/block_handler.go
@@ -29,17 +29,23 @@ func (s *Server) handleBlock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	blocked := s.eventStore.Add(event)
-	go s.ui.NotifyBlocked(blocked)
-	if blocked.Artifact.Product == "chrome" && blocked.Artifact.DisplayName == "" {
+
+	if shouldDelayBlockedUINotification(blocked) {
 		go func() {
 			enriched := s.enrichChromeBlockDisplayName(blocked)
+			s.ui.NotifyBlocked(enriched)
 			s.sendBlockedActivity(enriched)
 		}()
 	} else {
+		go s.ui.NotifyBlocked(blocked)
 		go s.sendBlockedActivity(blocked)
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func shouldDelayBlockedUINotification(event BlockEvent) bool {
+	return event.Artifact.Product == "chrome" && event.Artifact.DisplayName == ""
 }
 
 func (s *Server) enrichChromeBlockDisplayName(event BlockEvent) BlockEvent {
@@ -65,7 +71,6 @@ func (s *Server) enrichChromeBlockDisplayName(event BlockEvent) BlockEvent {
 	}
 
 	log.Printf("updated Chrome extension display name for %s: %q", event.Artifact.PackageName, displayName)
-	s.ui.NotifyBlockedUpdated(updated)
 	return updated
 }
 

--- a/internal/ingress/block_handler_test.go
+++ b/internal/ingress/block_handler_test.go
@@ -78,3 +78,51 @@ func TestBuildBlockedActivityEventUsesDisplayName(t *testing.T) {
 		t.Fatalf("expected display name to be used, got %q", got.SBOM.Entries[0].Packages[0].Name)
 	}
 }
+
+func TestShouldDelayBlockedUINotification(t *testing.T) {
+	tests := []struct {
+		name  string
+		event BlockEvent
+		want  bool
+	}{
+		{
+			name: "chrome without display name waits for enrichment",
+			event: BlockEvent{
+				Artifact: Artifact{
+					Product:     "chrome",
+					PackageName: "abcdefghijklmnop",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "chrome with display name does not wait",
+			event: BlockEvent{
+				Artifact: Artifact{
+					Product:     "chrome",
+					PackageName: "abcdefghijklmnop",
+					DisplayName: "Readable Extension",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non-chrome events do not wait",
+			event: BlockEvent{
+				Artifact: Artifact{
+					Product:     "npm",
+					PackageName: "left-pad",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldDelayBlockedUINotification(tt.event); got != tt.want {
+				t.Fatalf("shouldDelayBlockedUINotification() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Delayed UI notification for Chrome blocks until display name enriched
* Adjusted notification and activity flow to use enriched block events

**🔧 Refactors**
* Introduced shouldDelayBlockedUINotification helper to centralize delay logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110518271?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->