### PR TITLE
Fetch last 100 blocked events from core API on daemon startup to persist history across restarts

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -102,3 +102,62 @@ func SendActivity(ctx context.Context, config *config.ConfigInfo, event *Activit
 func SendRequestPackageInstallation(ctx context.Context, config *config.ConfigInfo, event *RequestPackageInstallationEvent) error {
 	return sendEvent(ctx, RequestPackageInstallationEndpoint, config, event)
 }
+
+func getRequest(ctx context.Context, endpoint string, cfg *config.ConfigInfo, queryParams url.Values) ([]byte, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("token is not set")
+	}
+	if cfg.DeviceID == "" {
+		return nil, fmt.Errorf("device ID is not set")
+	}
+
+	u, err := url.JoinPath(cfg.GetBaseURL(), endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build URL for %s: %w", endpoint, err)
+	}
+
+	if len(queryParams) > 0 {
+		u += "?" + queryParams.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", cfg.Token)
+	req.Header.Set("X-Device-Id", cfg.DeviceID)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send GET request to %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s failed with status %d", endpoint, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body from %s: %w", endpoint, err)
+	}
+
+	return body, nil
+}
+
+func FetchSubmittedEvents(ctx context.Context, cfg *config.ConfigInfo, limit int) (*FetchSubmittedEventsResponse, error) {
+	params := url.Values{}
+	params.Set("limit", fmt.Sprintf("%d", limit))
+
+	body, err := getRequest(ctx, FetchSubmittedEventsEndpoint, cfg, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp FetchSubmittedEventsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to decode fetchSubmittedEvents response: %w", err)
+	}
+
+	return &resp, nil
+}

--- a/internal/cloud/constants.go
+++ b/internal/cloud/constants.go
@@ -7,4 +7,5 @@ const (
 	ActivityEndpoint                   = "api/endpoint_protection/callbacks/reportActivity"
 	RequestPackageInstallationEndpoint = "api/endpoint_protection/callbacks/requestPackageInstallation"
 	UploadDeviceLogsEndpoint           = "api/endpoint_protection/callbacks/uploadDeviceLogs"
+	FetchSubmittedEventsEndpoint       = "api/endpoint_protection/callbacks/fetchSubmittedEvents"
 )

--- a/internal/cloud/events.go
+++ b/internal/cloud/events.go
@@ -31,6 +31,7 @@ type SBOMEvent struct {
 
 type ActivityEvent struct {
 	Action      string              `json:"action"`
+	BlockReason string              `json:"block_reason,omitempty"`
 	VersionInfo version.VersionInfo `json:"version"`
 	SBOM        sbom.SBOM           `json:"sbom"`
 }
@@ -46,6 +47,22 @@ type PackageInstallRequest struct {
 type EcosystemPackages struct {
 	Ecosystem string                  `json:"ecosystem"`
 	Packages  []PackageInstallRequest `json:"packages"`
+}
+
+type SubmittedEvent struct {
+	ID             int    `json:"id"`
+	Action         string `json:"action"`
+	BlockReason    string `json:"block_reason"`
+	Ecosystem      string `json:"ecosystem"`
+	PackageID      string `json:"package_id"`
+	PackageName    string `json:"package_name"`
+	PackageVersion string `json:"package_version"`
+	Timestamp      int64  `json:"timestamp"`
+	Status         string `json:"status"`
+}
+
+type FetchSubmittedEventsResponse struct {
+	Events []SubmittedEvent `json:"events"`
 }
 
 // RequestPackageInstallationEvent is the body sent to requestPackageInstallation.

--- a/internal/ingress/block_handler.go
+++ b/internal/ingress/block_handler.go
@@ -109,6 +109,7 @@ func buildBlockedActivityEvent(event BlockEvent, action string) *cloud.ActivityE
 
 	return &cloud.ActivityEvent{
 		Action:      action,
+		BlockReason: event.BlockReason,
 		VersionInfo: *version.Info,
 		SBOM: sbom.SBOM{
 			Entries: []sbom.EcosystemEntry{

--- a/internal/ingress/events.go
+++ b/internal/ingress/events.go
@@ -7,6 +7,14 @@ type Artifact struct {
 	DisplayName    string `json:"display_name,omitempty"`
 }
 
+// SameIdentity reports whether two artifacts refer to the same package,
+// ignoring DisplayName which may be populated asynchronously.
+func (a Artifact) SameIdentity(b Artifact) bool {
+	return a.Product == b.Product &&
+		a.PackageName == b.PackageName &&
+		a.PackageVersion == b.PackageVersion
+}
+
 // BlockEvent represents a blocked request notification from the proxy.
 type BlockEvent struct {
 	ID          string   `json:"id,omitempty"`

--- a/internal/ingress/permissions_handler.go
+++ b/internal/ingress/permissions_handler.go
@@ -22,15 +22,15 @@ func (s *Server) handlePermissionsUpdated(w http.ResponseWriter, r *http.Request
 		return
 	}
 	for _, e := range s.eventStore.List() {
-		if e.Status != "request_pending" {
+		if e.Status != "pending" {
 			continue
 		}
 		ecosystem := perms.Ecosystems[e.Artifact.Product]
 		pkg := strings.ToLower(e.Artifact.PackageName)
 		if sliceContainsFold(ecosystem.Exceptions.AllowedPackages, pkg) {
-			s.eventStore.UpdateStatus(e.ID, "request_approved")
+			s.eventStore.UpdateStatus(e.ID, "approved")
 		} else if sliceContainsFold(ecosystem.Exceptions.RejectedPackages, pkg) {
-			s.eventStore.UpdateStatus(e.ID, "request_rejected")
+			s.eventStore.UpdateStatus(e.ID, "rejected")
 		}
 	}
 	go s.ui.NotifyPermissionsUpdated(perms)

--- a/internal/ingress/request_bypass_handler.go
+++ b/internal/ingress/request_bypass_handler.go
@@ -22,8 +22,8 @@ func (s *Server) handleRequestBypass(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Received request-bypass event: name=%s, version=%s, product=%s", event.Artifact.PackageName, event.Artifact.PackageVersion, event.Artifact.Product)
 
 	for _, e := range s.eventStore.List() {
-		if e.Artifact == event.Artifact {
-			s.eventStore.UpdateStatus(e.ID, "request_pending")
+		if e.Artifact.SameIdentity(event.Artifact) {
+			s.eventStore.UpdateStatus(e.ID, "pending")
 		}
 	}
 

--- a/internal/ingress/server.go
+++ b/internal/ingress/server.go
@@ -9,8 +9,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 
+	"github.com/AikidoSec/safechain-internals/internal/cloud"
 	"github.com/AikidoSec/safechain-internals/internal/config"
 	"github.com/AikidoSec/safechain-internals/internal/proxy"
 )
@@ -110,6 +112,8 @@ func (s *Server) Start(ctx context.Context) error {
 
 	log.Printf("Ingress server listening on %s", s.addr)
 
+	go s.hydrateEventStore(ctx)
+
 	go func() {
 		<-ctx.Done()
 		err := s.Stop()
@@ -123,6 +127,38 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *Server) hydrateEventStore(ctx context.Context) {
+	resp, err := cloud.FetchSubmittedEvents(ctx, s.config, 100)
+	if err != nil {
+		log.Printf("failed to fetch submitted events for hydration: %v", err)
+		return
+	}
+
+	if len(resp.Events) == 0 {
+		return
+	}
+
+	events := make([]BlockEvent, 0, len(resp.Events))
+	for _, e := range resp.Events {
+		events = append(events, BlockEvent{
+			ID:          strconv.Itoa(e.ID),
+			TsMs:        e.Timestamp * 1000,
+			BlockReason: e.BlockReason,
+			Status:      e.Status,
+			Count:       1,
+			Artifact: Artifact{
+				Product:        e.Ecosystem,
+				PackageName:    e.PackageID,
+				PackageVersion: e.PackageVersion,
+				DisplayName:    e.PackageName,
+			},
+		})
+	}
+
+	s.eventStore.LoadHistorical(events)
+	log.Printf("hydrated event store with %d historical events", len(events))
 }
 
 func (s *Server) Stop() error {

--- a/internal/ingress/store.go
+++ b/internal/ingress/store.go
@@ -30,7 +30,7 @@ func (e *eventStore) Add(ev BlockEvent) BlockEvent {
 	}
 	// If the user already requested access for this artifact, carry that request status forward
 	for i := range e.events {
-		if e.events[i].Artifact == ev.Artifact && e.events[i].Status != "blocked" {
+		if e.events[i].Artifact.SameIdentity(ev.Artifact) && e.events[i].Status != "blocked" {
 			blocked.Status = e.events[i].Status
 		}
 	}
@@ -74,6 +74,17 @@ func (e *eventStore) List() []BlockEvent {
 	out := make([]BlockEvent, len(e.events))
 	copy(out, e.events)
 	return out
+}
+
+// LoadHistorical prepends pre-built historical events (oldest-first)
+// without generating new IDs. Used to seed the store on startup.
+func (e *eventStore) LoadHistorical(events []BlockEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.events = append(events, e.events...)
+	if len(e.events) > maxEvents {
+		e.events = e.events[len(e.events)-maxEvents:]
+	}
 }
 
 // UpdateStatus sets the status field on the event with the given id.

--- a/ui/frontend/src/pages/EventDetail.tsx
+++ b/ui/frontend/src/pages/EventDetail.tsx
@@ -118,7 +118,7 @@ export function EventDetail() {
     setError(null);
     try {
       await requestAccess(id);
-      setEvent((prev) => (prev ? { ...prev, status: "request_pending" } : null));
+      setEvent((prev) => (prev ? { ...prev, status: "pending" } : null));
       setRequestSent(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -170,7 +170,7 @@ export function EventDetail() {
   const canRequest = true;
   const info = BLOCK_REASON_INFO[event.block_reason];
 
-  if (event.status === "request_approved") {
+  if (event.status === "approved") {
     return (
       <div className="event-detail event-detail--full">
         <div className="request-success">
@@ -200,7 +200,7 @@ export function EventDetail() {
     );
   }
 
-  if (event.status === "request_rejected") {
+  if (event.status === "rejected") {
     return (
       <div className="event-detail event-detail--full">
         <div className="request-success">
@@ -230,7 +230,7 @@ export function EventDetail() {
     );
   }
 
-  if (requestSent || event.status === "request_pending") {
+  if (requestSent || event.status === "pending") {
     return (
       <div className="event-detail event-detail--full">
         <div className="request-success">

--- a/ui/frontend/src/pages/EventsList.tsx
+++ b/ui/frontend/src/pages/EventsList.tsx
@@ -140,11 +140,11 @@ export function EventsList() {
                   </td>
                   <td className="event-time">{formatEventTimeShort(ev.ts_ms)}</td>
                   <td>
-                    {ev.status === "request_approved" ? (
+                    {ev.status === "approved" ? (
                       <span className="status status-approved">approved</span>
-                    ) : ev.status === "request_pending" ? (
+                    ) : ev.status === "pending" ? (
                       <span className="status status-pending">requested</span>
-                    ) : ev.status === "request_rejected" ? (
+                    ) : ev.status === "rejected" ? (
                       <span className="status status-rejected">rejected</span>
                     ) : (
                       <span className={`reason-badge reason-badge--${ev.block_reason}`}>

--- a/ui/frontend/src/types.ts
+++ b/ui/frontend/src/types.ts
@@ -1,6 +1,6 @@
 export type BlockReason = "malware" | "rejected" | "block_all" | "request_install" | "new_package";
 
-export type EventStatus = "" | "blocked" | "request_pending" | "request_approved" | "request_rejected";
+export type EventStatus = "" | "blocked" | "pending" | "approved" | "rejected";
 
 export interface Artifact {
   product: string;

--- a/ui/mock/main.go
+++ b/ui/mock/main.go
@@ -105,7 +105,7 @@ func seedData() ([]BlockEvent, []TlsEvent) {
 			TsMs:        now - 15_000,
 			Artifact:    Artifact{Product: "nuget", Identifier: "Contoso.Analytics", Version: "3.1.0", DisplayName: "Contoso.Analytics"},
 			BlockReason: "request_install",
-			Status:      "request_pending",
+			Status:      "pending",
 			Count:       1,
 		},
 		{
@@ -113,7 +113,7 @@ func seedData() ([]BlockEvent, []TlsEvent) {
 			TsMs:        now - 360_000,
 			Artifact:    Artifact{Product: "chrome", Identifier: "pgojnojmmhpofjgdmaebadhbocahppod", Version: "", DisplayName: ""},
 			BlockReason: "request_install",
-			Status:      "request_approved",
+			Status:      "approved",
 			Count:       32,
 		},
 		{
@@ -121,7 +121,7 @@ func seedData() ([]BlockEvent, []TlsEvent) {
 			TsMs:        now - 400_000,
 			Artifact:    Artifact{Product: "open_vsx", Identifier: "ms-python.python", Version: "2024.0.0", DisplayName: "Python"},
 			BlockReason: "request_install",
-			Status:      "request_rejected",
+			Status:      "rejected",
 			Count:       1,
 		},
 		{
@@ -267,8 +267,8 @@ func (s *server) handleRequestAccess(w http.ResponseWriter, r *http.Request) {
 	defer s.mu.Unlock()
 	for i, e := range s.blocks {
 		if e.ID == id {
-			s.blocks[i].Status = "request_pending"
-			log.Printf("mock: request-access for %s → status=request_pending", id)
+			s.blocks[i].Status = "pending"
+			log.Printf("mock: request-access for %s → status=pending", id)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Fetched last 100 submitted blocked events and hydrated store on startup

**⚡ Enhancements**
* Added cloud GET helper and fetchSubmittedEvents API types and endpoint
* Included block_reason in ActivityEvent and populated it when sending activity

**🔧 Refactors**
* Renamed event status values (request_* → pending/approved/rejected) across UI
* Introduced Artifact.SameIdentity and switched artifact equality checks to it


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110834640?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->