### PR TITLE
Suppress cloud requests on 401 and re-prompt via setup wizard

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -68,7 +68,7 @@ func sendEventWithResponse(ctx context.Context, endpoint string, config *config.
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		if resp.StatusCode == http.StatusUnauthorized {
 			if config.MarkTokenUnauthorized(tokenUsed) {
 				log.Printf("Cloud auth rejected token %s with status %d; suppressing further cloud requests until the token changes", config.GetAnonymizedToken(), resp.StatusCode)
 				if err := config.Save(); err != nil {

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -32,8 +32,12 @@ func sendEvent(ctx context.Context, endpoint string, config *config.ConfigInfo, 
 }
 
 func sendEventWithResponse(ctx context.Context, endpoint string, config *config.ConfigInfo, event any) ([]byte, error) {
-	if config.Token == "" {
+	tokenUsed := config.Token
+	if tokenUsed == "" {
 		return nil, fmt.Errorf("token is not set")
+	}
+	if config.IsCurrentTokenUnauthorized() {
+		return nil, fmt.Errorf("token is marked unauthorized, skipping request")
 	}
 	if config.DeviceID == "" {
 		return nil, fmt.Errorf("device ID is not set")
@@ -54,7 +58,7 @@ func sendEventWithResponse(ctx context.Context, endpoint string, config *config.
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", config.Token)
+	req.Header.Set("Authorization", tokenUsed)
 	req.Header.Set("X-Device-Id", config.DeviceID)
 
 	resp, err := httpClient.Do(req)
@@ -64,6 +68,14 @@ func sendEventWithResponse(ctx context.Context, endpoint string, config *config.
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			if config.MarkTokenUnauthorized(tokenUsed) {
+				log.Printf("Cloud auth rejected token %s with status %d; suppressing further cloud requests until the token changes", config.GetAnonymizedToken(), resp.StatusCode)
+				if err := config.Save(); err != nil {
+					log.Printf("Failed to save config after suppressing unauthorized token: %v", err)
+				}
+			}
+		}
 		return nil, fmt.Errorf("request to %s failed with status %d", endpoint, resp.StatusCode)
 	}
 

--- a/internal/cloud/cloud_test.go
+++ b/internal/cloud/cloud_test.go
@@ -1,0 +1,120 @@
+package cloud
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AikidoSec/safechain-internals/internal/config"
+	"github.com/AikidoSec/safechain-internals/internal/platform"
+)
+
+// withTempRunDir points platform.GetConfig().RunDir at a t.TempDir for the
+// duration of the test and restores the prior value on cleanup. Tests that
+// call config.Save() need this so they don't write into the real run dir.
+func withTempRunDir(t *testing.T) {
+	t.Helper()
+	pc := platform.GetConfig()
+	prev := pc.RunDir
+	pc.RunDir = t.TempDir()
+	t.Cleanup(func() { pc.RunDir = prev })
+}
+
+func TestUnauthorizedTokenIsSuppressedUntilTokenChanges(t *testing.T) {
+	withTempRunDir(t)
+	Init()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := &config.ConfigInfo{
+		Token:    "bad-token",
+		DeviceID: "device-1",
+		BaseURL:  server.URL,
+	}
+
+	event := &HeartbeatEvent{}
+
+	if _, err := SendHeartbeat(context.Background(), cfg, event); err == nil {
+		t.Fatal("expected first heartbeat to fail with unauthorized")
+	}
+	if !cfg.IsCurrentTokenUnauthorized() {
+		t.Fatal("expected token to be marked unauthorized after 401")
+	}
+	if requests != 1 {
+		t.Fatalf("expected one network request, got %d", requests)
+	}
+
+	if _, err := SendHeartbeat(context.Background(), cfg, event); err == nil {
+		t.Fatal("expected second heartbeat to be skipped")
+	}
+	if requests != 1 {
+		t.Fatalf("expected unauthorized token suppression to skip network retry, got %d requests", requests)
+	}
+
+	cfg.SetToken("good-token")
+	if cfg.IsCurrentTokenUnauthorized() {
+		t.Fatal("expected unauthorized marker to clear when token changes")
+	}
+
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if _, err := SendHeartbeat(context.Background(), cfg, event); err != nil {
+		t.Fatalf("expected heartbeat with new token to succeed, got %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected request after token change, got %d total requests", requests)
+	}
+}
+
+// Simulates the race where a 401 for a token-in-flight arrives after the user
+// has already replaced the token. The new token must not be marked unauthorized.
+func TestStale401DoesNotPoisonReplacedToken(t *testing.T) {
+	withTempRunDir(t)
+	Init()
+
+	received := make(chan string, 1)
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.Header.Get("Authorization")
+		<-released
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := &config.ConfigInfo{
+		Token:    "bad-token",
+		DeviceID: "device-1",
+		BaseURL:  server.URL,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := SendHeartbeat(context.Background(), cfg, &HeartbeatEvent{})
+		done <- err
+	}()
+
+	if got := <-received; got != "bad-token" {
+		t.Fatalf("expected request to be sent with bad-token, got %q", got)
+	}
+	cfg.SetToken("good-token")
+	close(released)
+
+	if err := <-done; err == nil {
+		t.Fatal("expected in-flight heartbeat to fail with unauthorized")
+	}
+	if cfg.IsCurrentTokenUnauthorized() {
+		t.Fatal("stale 401 must not mark the replacement token as unauthorized")
+	}
+	if cfg.LastUnauthorizedToken != "" {
+		t.Fatalf("expected LastUnauthorizedToken to remain cleared, got %q", cfg.LastUnauthorizedToken)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type ConfigInfo struct {
 
 	LastHandledLogCollectRequestAt int64  `json:"last_handled_log_collect_request_at,omitempty"`
 	LastHandledTargetUpdateVersion string `json:"last_handled_target_update_version,omitempty"`
+	LastUnauthorizedToken          string `json:"last_unauthorized_token,omitempty"`
 }
 
 func (c *ConfigInfo) GetProxyMode() string {
@@ -79,6 +80,25 @@ func (c *ConfigInfo) GetAnonymizedToken() string {
 		return "***" + c.Token[len(c.Token)-4:]
 	}
 	return c.Token
+}
+
+// SetToken records a new token and clears any prior unauthorized marker so
+// the daemon will retry against core.
+func (c *ConfigInfo) SetToken(token string) {
+	c.Token = token
+	c.LastUnauthorizedToken = ""
+}
+
+func (c *ConfigInfo) IsCurrentTokenUnauthorized() bool {
+	return c.Token != "" && c.Token == c.LastUnauthorizedToken
+}
+
+func (c *ConfigInfo) MarkTokenUnauthorized(token string) bool {
+	if token == "" || c.Token != token || c.LastUnauthorizedToken == token {
+		return false
+	}
+	c.LastUnauthorizedToken = token
+	return true
 }
 
 func (c *ConfigInfo) String() string {

--- a/internal/ingress/setup_handler.go
+++ b/internal/ingress/setup_handler.go
@@ -48,6 +48,8 @@ func ComputeSetupSteps(ctx context.Context, cfg *config.ConfigInfo) []string {
 
 	if cfg.Token == "" {
 		steps = append(steps, "token")
+	} else if cfg.IsCurrentTokenUnauthorized() {
+		steps = append(steps, "invalid-token")
 	}
 
 	if installed, err := IsNetworkExtensionInstalled(ctx); err != nil || !installed {

--- a/internal/ingress/token_handler.go
+++ b/internal/ingress/token_handler.go
@@ -29,7 +29,7 @@ func (s *Server) handleSetToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.config.Token = body.Token
+	s.config.SetToken(body.Token)
 	if err := s.config.Save(); err != nil {
 		log.Printf("ingress: failed to save config after setting token: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/ui/frontend/src/pages/InstallPage.tsx
+++ b/ui/frontend/src/pages/InstallPage.tsx
@@ -140,6 +140,8 @@ export function InstallPage() {
     setTokenInput("");
     if (currentIdx + 1 < steps.length) {
       setCurrentIdx((i) => i + 1);
+    } else {
+      closeInstallWindow();
     }
   }
 

--- a/ui/frontend/src/pages/InstallPage.tsx
+++ b/ui/frontend/src/pages/InstallPage.tsx
@@ -24,9 +24,9 @@ import { SetupStepAllowVpn } from "./SetupStepAllowVpn";
 import { SetupStepStartProxy } from "./SetupStepStartProxy";
 import { SetupStepInstallCa } from "./SetupStepInstallCa";
 
-type StepId = "token" | "install-extension" | "enable-extension" | "allow-vpn" | "start-proxy" | "install-ca" | "reboot";
+type StepId = "token" | "invalid-token" | "install-extension" | "enable-extension" | "allow-vpn" | "start-proxy" | "install-ca" | "reboot";
 
-const VALID_STEPS = new Set<string>(["token", "install-extension", "enable-extension", "allow-vpn", "start-proxy", "install-ca", "reboot"]);
+const VALID_STEPS = new Set<string>(["token", "invalid-token", "install-extension", "enable-extension", "allow-vpn", "start-proxy", "install-ca", "reboot"]);
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -42,6 +42,7 @@ async function pollUntil(check: () => Promise<boolean>, intervalMs: number, maxA
 
 const STEP_ACTIONS: Partial<Record<StepId, (input?: string) => Promise<void>>> = {
   token: (input) => setToken(input ?? ""),
+  "invalid-token": (input) => setToken(input ?? ""),
   "install-extension": async () => {
     await installExtension();
     if (await isExtensionInstalled()) return;
@@ -114,7 +115,7 @@ export function InstallPage() {
 
   async function handleAction() {
     if (!currentStep || currentStep === "reboot") return;
-    if (currentStep === "token" && !tokenInput.trim()) return;
+    if ((currentStep === "token" || currentStep === "invalid-token") && !tokenInput.trim()) return;
 
     setPhase("working");
     setErrorMsg("");
@@ -122,7 +123,7 @@ export function InstallPage() {
       const action = STEP_ACTIONS[currentStep];
       if (!action) return;
       await action(tokenInput.trim());
-      if (currentStep === "token") {
+      if (currentStep === "token" || currentStep === "invalid-token") {
         handleNext();
       } else {
         setPhase("done");
@@ -198,6 +199,15 @@ export function InstallPage() {
             {...stepProps}
             tokenInput={tokenInput}
             onTokenChange={setTokenInput}
+          />
+        );
+      case "invalid-token":
+        return (
+          <SetupStepToken
+            {...stepProps}
+            tokenInput={tokenInput}
+            onTokenChange={setTokenInput}
+            invalidToken
           />
         );
       case "install-extension":

--- a/ui/frontend/src/pages/SetupStepToken.tsx
+++ b/ui/frontend/src/pages/SetupStepToken.tsx
@@ -8,17 +8,22 @@ interface Props {
   onAction: () => void;
   tokenInput: string;
   onTokenChange: (value: string) => void;
+  invalidToken?: boolean;
 }
 
-export function SetupStepToken({ stepNumber, totalSteps, phase, errorMsg, onAction, tokenInput, onTokenChange }: Props) {
+export function SetupStepToken({ stepNumber, totalSteps, phase, errorMsg, onAction, tokenInput, onTokenChange, invalidToken = false }: Props) {
   return (
     <SetupStepLayout
       stepNumber={stepNumber}
       totalSteps={totalSteps}
       heading="Connect your device"
-      title="Enter your Aikido token"
-      hint="Paste your Aikido Endpoint Protection token to connect this device to your organization."
-      buttonLabel="Set Token"
+      title={invalidToken ? "Replace your Aikido token" : "Enter your Aikido token"}
+      hint={
+        invalidToken
+          ? "The configured token was rejected by Aikido. Paste a valid Endpoint Protection token to reconnect this device."
+          : "Paste your Aikido Endpoint Protection token to connect this device to your organization."
+      }
+      buttonLabel={invalidToken ? "Replace Token" : "Set Token"}
       phase={phase}
       errorMsg={errorMsg}
       onAction={onAction}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Suppressed cloud requests when server rejected token and persisted marker
* Added config fields and methods to mark and check unauthorized tokens
* Extended setup wizard to include an invalid-token step and flow
* Updated UI to prompt replacing rejected token with contextual messaging
* Changed token setter to clear unauthorized marker when new token set


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110855760?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->