### PR TITLE
Remove service management instructions and update macOS packaging

### DIFF
--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -179,9 +179,14 @@ if /usr/libexec/PlistBuddy -c "Print" "$COMPONENT_PLIST" >/dev/null 2>&1; then
         /usr/libexec/PlistBuddy -c "Set :${IDX}:BundleHasStrictIdentifier false" "$COMPONENT_PLIST" 2>/dev/null || true
         /usr/libexec/PlistBuddy -c "Set :${IDX}:BundleIsRelocatable false" "$COMPONENT_PLIST" 2>/dev/null || true
         /usr/libexec/PlistBuddy -c "Set :${IDX}:BundleIsVersionChecked false" "$COMPONENT_PLIST" 2>/dev/null || true
+        # Drop ChildBundles so PackageInfo / Distribution only advertise the
+        # top-level apps to MDM systems (Intune rejects packages that expose
+        # internal Swift resource bundles or system extensions as installable
+        # bundles). The payload is unaffected.
+        /usr/libexec/PlistBuddy -c "Delete :${IDX}:ChildBundles" "$COMPONENT_PLIST" 2>/dev/null || true
         IDX=$((IDX + 1))
     done
-    echo "Configured $IDX bundle entries in component plist (all non-relocatable)"
+    echo "Configured $IDX bundle entries in component plist (no child bundles, non-relocatable)"
 fi
 
 echo "Building package..."

--- a/packaging/macos/conclusion.html
+++ b/packaging/macos/conclusion.html
@@ -40,14 +40,6 @@
     <p><strong>Logs Location:</strong><br>
     <span class="path">/Library/Logs/AikidoSecurity/EndpointProtection</span></p>
     
-    <p><strong>Managing the Service:</strong></p>
-    <ul>
-        <li>The agent runs as a system daemon and starts automatically at boot</li>
-        <li>View status: <span class="path">sudo launchctl list | grep endpointprotection</span></li>
-        <li>Stop: <span class="path">sudo launchctl bootout system/com.aikidosecurity.endpointprotection</span></li>
-        <li>Start: <span class="path">sudo launchctl bootstrap system /Library/LaunchDaemons/com.aikidosecurity.endpointprotection.plist</span></li>
-    </ul>
-    
     <p>For more information, visit <a href="https://github.com/AikidoSec/safechain-internals">github.com/AikidoSec/safechain-internals</a></p>
 </body>
 </html>

--- a/packaging/macos/install-local.sh
+++ b/packaging/macos/install-local.sh
@@ -52,6 +52,11 @@ echo ""
 sudo installer -pkg "$PKG_FILE" -target / -verbose
 
 if [ $? -eq 0 ]; then
+    # Back-date the install marker so its mtime is well before the current
+    # boot time. The daemon compares this file's mtime against system boot
+    # time to decide whether a post-install reboot is still pending; without
+    # this, every local reinstall would prompt for a reboot.
+    # Development-only hack!
     sudo touch -t 202501151000 "/Library/Application Support/AikidoSecurity/EndpointProtection/run/.installed_at"
 
     echo ""

--- a/packaging/macos/install-local.sh
+++ b/packaging/macos/install-local.sh
@@ -52,6 +52,8 @@ echo ""
 sudo installer -pkg "$PKG_FILE" -target / -verbose
 
 if [ $? -eq 0 ]; then
+    sudo touch -t 202501151000 "/Library/Application Support/AikidoSecurity/EndpointProtection/run/.installed_at"
+
     echo ""
     echo "========================================="
     echo "✓ Installation Complete!"

--- a/packaging/macos/install-local.sh
+++ b/packaging/macos/install-local.sh
@@ -56,7 +56,6 @@ if [ $? -eq 0 ]; then
     # boot time. The daemon compares this file's mtime against system boot
     # time to decide whether a post-install reboot is still pending; without
     # this, every local reinstall would prompt for a reboot.
-    # Development-only hack!
     sudo touch -t 202501151000 "/Library/Application Support/AikidoSecurity/EndpointProtection/run/.installed_at"
 
     echo ""


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Back-dated local install marker to prevent unnecessary reboot prompts.
* Removed ChildBundles entries from component plist during package build.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111869794?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->