### PR TITLE
install cargo-fuzz on stable toolchain

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,13 +99,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
+          toolchain: stable
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+        with:
           toolchain: nightly
       - uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/cargo-fuzz
           key: cargo-fuzz-bin-${{ env.CARGO_FUZZ_VERSION }}
       - run: echo "${{ runner.tool_cache }}/cargo-fuzz/bin" >> $GITHUB_PATH
-      - run: cargo install --root "${{ runner.tool_cache }}/cargo-fuzz" --version ${{ env.CARGO_FUZZ_VERSION }} cargo-fuzz --locked
+      - run: cargo +stable install --root "${{ runner.tool_cache }}/cargo-fuzz" --version ${{ env.CARGO_FUZZ_VERSION }} cargo-fuzz --locked
       - run: CARGO_PROFILE_RELEASE_LTO=false cargo fuzz build --fuzz-dir ./proxy-fuzz ${{ matrix.fuzz_target }}
       - run: CARGO_PROFILE_RELEASE_LTO=false cargo fuzz run --fuzz-dir ./proxy-fuzz ${{ matrix.fuzz_target }} -- -max_total_time=${{ env.FUZZ_TIME }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Installed cargo-fuzz with the stable Rust toolchain in CI


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112028260?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->