### PR TITLE
ci: install Visual Studio 2022 Build Tools on Windows runners

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -95,21 +95,23 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            Write-Host "Installing Microsoft.VisualStudio.2022.BuildTools (attempt $i/$maxAttempts)"
-            winget install --source winget --exact `
-              --id Microsoft.VisualStudio.2022.BuildTools `
-              --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" `
-              --accept-package-agreements --accept-source-agreements `
-              --disable-interactivity --silent
-            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq -1978335189) {
-              exit 0
-            }
-            Write-Warning "winget install failed with exit code $LASTEXITCODE, retrying..."
-            Start-Sleep -Seconds 10
+          # Suppresses the line-by-line download progress bar (animated, ugly in CI logs).
+          $ProgressPreference = "SilentlyContinue"
+          $installerUrl = "https://aka.ms/vs/17/release/vs_buildtools.exe"
+          $installerPath = Join-Path $env:RUNNER_TEMP "vs_buildtools.exe"
+          Write-Host "Downloading VS 2022 Build Tools installer..."
+          Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath
+          Write-Host "Running VS 2022 Build Tools installer (quiet)..."
+          $proc = Start-Process -FilePath $installerPath -Wait -PassThru -ArgumentList @(
+            '--quiet', '--wait', '--norestart', '--nocache',
+            '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+            '--includeRecommended'
+          )
+          # 0 = success, 3010 = success but reboot pending; both are fine for our use.
+          if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+            throw "VS 2022 Build Tools installer exited with code $($proc.ExitCode)"
           }
-          throw "Failed to install Microsoft.VisualStudio.2022.BuildTools after $maxAttempts attempts"
+          Write-Host "VS 2022 Build Tools installed."
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
@@ -168,21 +170,23 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            Write-Host "Installing Microsoft.VisualStudio.2022.BuildTools (attempt $i/$maxAttempts)"
-            winget install --source winget --exact `
-              --id Microsoft.VisualStudio.2022.BuildTools `
-              --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" `
-              --accept-package-agreements --accept-source-agreements `
-              --disable-interactivity --silent
-            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq -1978335189) {
-              exit 0
-            }
-            Write-Warning "winget install failed with exit code $LASTEXITCODE, retrying..."
-            Start-Sleep -Seconds 10
+          # Suppresses the line-by-line download progress bar (animated, ugly in CI logs).
+          $ProgressPreference = "SilentlyContinue"
+          $installerUrl = "https://aka.ms/vs/17/release/vs_buildtools.exe"
+          $installerPath = Join-Path $env:RUNNER_TEMP "vs_buildtools.exe"
+          Write-Host "Downloading VS 2022 Build Tools installer..."
+          Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath
+          Write-Host "Running VS 2022 Build Tools installer (quiet)..."
+          $proc = Start-Process -FilePath $installerPath -Wait -PassThru -ArgumentList @(
+            '--quiet', '--wait', '--norestart', '--nocache',
+            '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+            '--includeRecommended'
+          )
+          # 0 = success, 3010 = success but reboot pending; both are fine for our use.
+          if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+            throw "VS 2022 Build Tools installer exited with code $($proc.ExitCode)"
           }
-          throw "Failed to install Microsoft.VisualStudio.2022.BuildTools after $maxAttempts attempts"
+          Write-Host "VS 2022 Build Tools installed."
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,7 +126,11 @@ jobs:
           path: SafeChainL7Proxy.exe
 
   build-windows-l4-proxy:
-    runs-on: windows-latest
+    # Pinned to windows-2022: the current windows-latest image breaks
+    # cmake's "Visual Studio 17 2022" generator detection used by
+    # rama-boring-sys, which fails the BoringSSL build. The other Windows
+    # jobs in this workflow are not affected.
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -91,6 +91,26 @@ jobs:
 
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
 
+      - name: Install Visual Studio 2022 Build Tools (C++)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            Write-Host "Installing Microsoft.VisualStudio.2022.BuildTools (attempt $i/$maxAttempts)"
+            winget install --source winget --exact `
+              --id Microsoft.VisualStudio.2022.BuildTools `
+              --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" `
+              --accept-package-agreements --accept-source-agreements `
+              --disable-interactivity --silent
+            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq -1978335189) {
+              exit 0
+            }
+            Write-Warning "winget install failed with exit code $LASTEXITCODE, retrying..."
+            Start-Sleep -Seconds 10
+          }
+          throw "Failed to install Microsoft.VisualStudio.2022.BuildTools after $maxAttempts attempts"
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
@@ -126,11 +146,7 @@ jobs:
           path: SafeChainL7Proxy.exe
 
   build-windows-l4-proxy:
-    # Pinned to windows-2022: the current windows-latest image breaks
-    # cmake's "Visual Studio 17 2022" generator detection used by
-    # rama-boring-sys, which fails the BoringSSL build. The other Windows
-    # jobs in this workflow are not affected.
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -147,6 +163,26 @@ jobs:
           fi
 
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+
+      - name: Install Visual Studio 2022 Build Tools (C++)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            Write-Host "Installing Microsoft.VisualStudio.2022.BuildTools (attempt $i/$maxAttempts)"
+            winget install --source winget --exact `
+              --id Microsoft.VisualStudio.2022.BuildTools `
+              --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" `
+              --accept-package-agreements --accept-source-agreements `
+              --disable-interactivity --silent
+            if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq -1978335189) {
+              exit 0
+            }
+            Write-Warning "winget install failed with exit code $LASTEXITCODE, retrying..."
+            Start-Sleep -Seconds 10
+          }
+          throw "Failed to install Microsoft.VisualStudio.2022.BuildTools after $maxAttempts attempts"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,28 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rustfmt
+      - name: Install Visual Studio 2022 Build Tools (C++)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          # Suppresses the line-by-line download progress bar (animated, ugly in CI logs).
+          $ProgressPreference = "SilentlyContinue"
+          $installerUrl = "https://aka.ms/vs/17/release/vs_buildtools.exe"
+          $installerPath = Join-Path $env:RUNNER_TEMP "vs_buildtools.exe"
+          Write-Host "Downloading VS 2022 Build Tools installer..."
+          Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath
+          Write-Host "Running VS 2022 Build Tools installer (quiet)..."
+          $proc = Start-Process -FilePath $installerPath -Wait -PassThru -ArgumentList @(
+            '--quiet', '--wait', '--norestart', '--nocache',
+            '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+            '--includeRecommended'
+          )
+          # 0 = success, 3010 = success but reboot pending; both are fine for our use.
+          if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+            throw "VS 2022 Build Tools installer exited with code $($proc.ExitCode)"
+          }
+          Write-Host "VS 2022 Build Tools installed."
       - name: Install Windows SDK + WDK
         if: runner.os == 'Windows'
         shell: powershell


### PR DESCRIPTION
The current windows-latest runner image no longer ships a VS instance that cmake's `Visual Studio 17 2022` generator can find, breaking `rama-boring-sys` for both `build-windows-proxy` and `build-windows-l4-proxy`. Pinning to `windows-2022` was not viable: the SDK/WDK winget step that `build-windows-l4-proxy` relies on fails there.

Install `Microsoft.VisualStudio.2022.BuildTools` (VCTools workload) via winget on both jobs that hit BoringSSL's cmake build.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Installed Visual Studio 2022 Build Tools on Windows CI runners
* Added retry wrapper for winget install of Windows SDK and WDK


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112724009?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->