### PR TITLE
Restore pypi test command via in-proxy metadata synthesis

### DIFF
--- a/proxy-bin-l7/src/client/mock_server/pypi_registry.rs
+++ b/proxy-bin-l7/src/client/mock_server/pypi_registry.rs
@@ -4,7 +4,7 @@ use rama::{
     Service,
     http::{
         Request, Response, StatusCode,
-        service::web::response::{IntoResponse, Json},
+        service::web::response::{Html, IntoResponse, Json},
     },
     service::service_fn,
 };
@@ -19,10 +19,32 @@ pub(super) fn web_svc() -> impl Service<Request, Output = Response, Error = Infa
 /// Handles PyPI registry requests for the mock server.
 ///
 /// Serves the legacy JSON metadata for [`FRESH_PYPI_PACKAGE_NAME`] at
-/// `/pypi/<name>/json`, including both a stable older release (`0.9.0`) and
-/// the current fresh version. All other paths return `200 OK` with an empty body.
+/// `/pypi/<name>/json` and the PEP 503 Simple HTML index at `/simple/<name>/`,
+/// each including both a stable older release (`0.9.0`) and the current fresh
+/// version. All other paths return `200 OK` with an empty body.
 async fn handle(req: Request) -> Result<Response, Infallible> {
     let path = req.uri().path();
+
+    if path == format!("/simple/{FRESH_PYPI_PACKAGE_NAME}/") {
+        let body = format!(
+            r#"<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="pypi:repository-version" content="1.0">
+    <title>Links for {name}</title>
+  </head>
+  <body>
+    <h1>Links for {name}</h1>
+    <a href="https://files.pythonhosted.org/packages/source/b/{name}/{name}-0.9.0.tar.gz">{name}-0.9.0.tar.gz</a><br/>
+    <a href="https://files.pythonhosted.org/packages/source/b/{name}/{name}-{version}.tar.gz">{name}-{version}.tar.gz</a><br/>
+  </body>
+</html>
+"#,
+            name = FRESH_PYPI_PACKAGE_NAME,
+            version = FRESH_PYPI_PACKAGE_VERSION,
+        );
+        return Ok(Html(body).into_response());
+    }
 
     if path == format!("/pypi/{FRESH_PYPI_PACKAGE_NAME}/json") {
         let body = json!({

--- a/proxy-bin-l7/src/test/e2e/test_proxy/firewall_pypi.rs
+++ b/proxy-bin-l7/src/test/e2e/test_proxy/firewall_pypi.rs
@@ -262,6 +262,37 @@ async fn test_pypi_https_package_new_package_blocked() {
 
 #[tokio::test]
 #[tracing_test::traced_test]
+async fn test_pypi_https_simple_index_min_package_age_rewrite() {
+    // Regression coverage for the dispatch in `RulePyPI::evaluate_response`:
+    // a real package's Simple HTML index must still flow through the min-age
+    // rewriter (not the test-command synthesis short-circuit). We expect the
+    // recent `FRESH_PYPI_PACKAGE_VERSION` link to be stripped while the older
+    // `0.9.0` link survives.
+    let runtime = e2e::runtime::get().await;
+    let client = runtime.client_with_http_proxy().await;
+
+    let resp = client
+        .get(format!(
+            "https://pypi.org/simple/{FRESH_PYPI_PACKAGE_NAME}/"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(StatusCode::OK, resp.status());
+
+    let body = resp.try_into_string().await.unwrap();
+    assert!(
+        body.contains("0.9.0.tar.gz"),
+        "expected the older 0.9.0 link to survive min-age rewrite, got body: {body}"
+    );
+    assert!(
+        !body.contains(&format!("{FRESH_PYPI_PACKAGE_VERSION}.tar.gz")),
+        "expected the fresh {FRESH_PYPI_PACKAGE_VERSION} link to be stripped from the Simple HTML index, got body: {body}"
+    );
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
 async fn test_pypi_https_package_new_package_not_blocked_via_policy_cutoff() {
     // The policy sets minimum_allowed_age_timestamp far in the future, making the
     // cutoff larger than our test entry's released_on (year ~2255) — so the package is no

--- a/proxy-bin-l7/src/test/e2e/test_proxy/firewall_pypi.rs
+++ b/proxy-bin-l7/src/test/e2e/test_proxy/firewall_pypi.rs
@@ -263,11 +263,7 @@ async fn test_pypi_https_package_new_package_blocked() {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn test_pypi_https_simple_index_min_package_age_rewrite() {
-    // Regression coverage for the dispatch in `RulePyPI::evaluate_response`:
-    // a real package's Simple HTML index must still flow through the min-age
-    // rewriter (not the test-command synthesis short-circuit). We expect the
-    // recent `FRESH_PYPI_PACKAGE_VERSION` link to be stripped while the older
-    // `0.9.0` link survives.
+    // Coverage for simple HTML index must
     let runtime = e2e::runtime::get().await;
     let client = runtime.client_with_http_proxy().await;
 

--- a/proxy-lib/src/http/firewall/rule/pypi/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/mod.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use rama::{
     Service,
     error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    extensions::ExtensionsRef as _,
     graceful::ShutdownGuard,
     http::{Request, Response, Uri},
     net::address::Domain,
@@ -14,10 +15,13 @@ use crate::{
     endpoint_protection::{
         EcosystemKey, PackagePolicyDecision, PolicyEvaluator, RemoteEndpointConfig,
     },
-    http::firewall::{
-        domain_matcher::DomainMatcher,
-        events::{Artifact, BlockReason},
-        notifier::EventNotifier,
+    http::{
+        RequestMetaUri,
+        firewall::{
+            domain_matcher::DomainMatcher,
+            events::{Artifact, BlockReason},
+            notifier::EventNotifier,
+        },
     },
     package::{
         malware_list::RemoteMalwareList, name_formatter::LowerCasePackageName,
@@ -37,6 +41,9 @@ use self::min_package_age::MinPackageAgePyPI;
 
 mod parser;
 use parser::{PackageInfo, parse_package_info_from_path};
+
+mod test_packages;
+use test_packages::{is_test_package, synthesize_metadata_response};
 
 type PyPIPackageName = LowerCasePackageName;
 type PyPIRemoteMalwareList = RemoteMalwareList<PyPIPackageName>;
@@ -184,6 +191,15 @@ impl Rule for RulePyPI {
             }
         }
 
+        if is_test_package(&package_info.name) {
+            tracing::debug!(package = %package_info.name, version = ?package_info.version, "blocked PyPI test package download (synthetic test command)");
+            return Ok(RequestAction::Block(BlockedRequest::blocked(
+                req,
+                Self::blocked_artifact(package_info),
+                BlockReason::Malware,
+            )));
+        }
+
         if self.is_blocked(&package_info)? {
             tracing::debug!(package = %package_info.name, version = ?package_info.version, "blocked PyPI package download");
             return Ok(RequestAction::Block(BlockedRequest::blocked(
@@ -219,13 +235,30 @@ impl Rule for RulePyPI {
         &self,
         req: HttpRequestMatcherView<'_>,
     ) -> bool {
-        self.maybe_min_package_age.is_some()
-            && parse_package_info_from_path(req.uri.path())
-                .is_some_and(|package_info| package_info.is_metadata_request())
+        let Some(package_info) = parse_package_info_from_path(req.uri.path()) else {
+            return false;
+        };
+        if !package_info.is_metadata_request() {
+            return false;
+        }
+        // Either we have min-package-age rewriting active (which inspects every
+        // metadata response), or this is one of our sentinel test packages
+        self.maybe_min_package_age.is_some() || is_test_package(&package_info.name)
     }
 
     #[inline(always)]
     async fn evaluate_response(&self, resp: Response) -> Result<Response, BoxError> {
+        if let Some(synthetic) = resp
+            .extensions()
+            .get_ref::<RequestMetaUri>()
+            .and_then(|RequestMetaUri(uri)| synthesize_metadata_response(uri))
+        {
+            tracing::info!(
+                "PyPI test-command metadata synthesized: returning offline index for sentinel package"
+            );
+            return Ok(synthetic);
+        }
+
         match &self.maybe_min_package_age {
             Some(min_package_age) => {
                 min_package_age

--- a/proxy-lib/src/http/firewall/rule/pypi/test_packages/mod.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/test_packages/mod.rs
@@ -1,0 +1,104 @@
+//! Synthetic-metadata path for the agent's PyPI test command.
+
+use rama::http::{
+    Response, Uri,
+    service::web::response::{Html, IntoResponse, Json},
+};
+
+use crate::http::headers::make_response_uncacheable;
+
+use super::PyPIPackageName;
+use super::parser::parse_package_info_from_path;
+
+pub(super) const TEST_PACKAGES: &[&str] = &["safe-chain-pi-test", "aikido-endpoint-test"];
+
+const TEST_PACKAGE_VERSION: &str = "0.1.0";
+
+pub(super) fn is_test_package(name: &PyPIPackageName) -> bool {
+    TEST_PACKAGES
+        .iter()
+        .any(|candidate| PyPIPackageName::from(*candidate) == *name)
+}
+
+/// If `uri` targets a metadata endpoint for one of the test packages, build a
+/// synthetic metadata response that advertises a single wheel.
+/// Returns `None` for any URL that does not match a test package, so callers fall
+/// through to the normal upstream/min-package-age path.
+pub(super) fn synthesize_metadata_response(uri: &Uri) -> Option<Response> {
+    let path = uri.path();
+    let package_info = parse_package_info_from_path(path)?;
+    if !package_info.is_metadata_request() {
+        return None;
+    }
+
+    let canonical_name = TEST_PACKAGES
+        .iter()
+        .copied()
+        .find(|candidate| PyPIPackageName::from(*candidate) == package_info.name)?;
+
+    let response = if path.starts_with("/pypi/") && path.ends_with("/json") {
+        synthesize_json(canonical_name)
+    } else {
+        synthesize_simple_html(canonical_name)
+    };
+
+    Some(response)
+}
+
+fn wheel_filename(canonical_name: &str) -> String {
+    let dist = canonical_name.replace('-', "_");
+    format!("{dist}-{TEST_PACKAGE_VERSION}-py3-none-any.whl")
+}
+
+fn wheel_url(canonical_name: &str) -> String {
+    format!(
+        "https://files.pythonhosted.org/packages/00/00/{}",
+        wheel_filename(canonical_name)
+    )
+}
+
+fn synthesize_simple_html(canonical_name: &str) -> Response {
+    let body = format!(
+        r#"<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="pypi:repository-version" content="1.0">
+    <title>Links for {canonical_name}</title>
+  </head>
+  <body>
+    <h1>Links for {canonical_name}</h1>
+    <a href="{wheel}">{filename}</a><br/>
+  </body>
+</html>
+"#,
+        wheel = wheel_url(canonical_name),
+        filename = wheel_filename(canonical_name),
+    );
+
+    let mut response = Html(body).into_response();
+    make_response_uncacheable(response.headers_mut());
+    response
+}
+
+fn synthesize_json(canonical_name: &str) -> Response {
+    let filename = wheel_filename(canonical_name);
+    let url = wheel_url(canonical_name);
+    let file_entry = serde_json::json!({
+        "filename": filename,
+        "url": url,
+        "packagetype": "bdist_wheel",
+        "python_version": "py3",
+    });
+    let body = serde_json::json!({
+        "info": { "name": canonical_name, "version": TEST_PACKAGE_VERSION },
+        "urls": [file_entry.clone()],
+        "releases": { TEST_PACKAGE_VERSION: [file_entry] },
+    });
+
+    let mut response = Json(body).into_response();
+    make_response_uncacheable(response.headers_mut());
+    response
+}
+
+#[cfg(test)]
+mod tests;

--- a/proxy-lib/src/http/firewall/rule/pypi/test_packages/tests.rs
+++ b/proxy-lib/src/http/firewall/rule/pypi/test_packages/tests.rs
@@ -1,0 +1,94 @@
+use rama::http::StatusCode;
+
+use super::*;
+
+#[test]
+fn is_test_package_recognizes_canonical_names() {
+    for &name in TEST_PACKAGES {
+        assert!(is_test_package(&PyPIPackageName::from(name)));
+    }
+}
+
+#[test]
+fn is_test_package_after_parser_normalization() {
+    // The parser uses `normalize_package_name` (`_` -> `-`, then ASCII-lowercase
+    // via `LowerCasePackageName`). We replicate that pipeline here so the test
+    // mirrors how `is_test_package` is actually invoked from `evaluate_request`.
+    for raw in ["Safe_Chain_Pi_Test", "AIKIDO_ENDPOINT_TEST"] {
+        let normalized = super::super::parser::normalize_package_name(raw);
+        assert!(
+            is_test_package(&normalized),
+            "expected {raw} to be recognized as a test package"
+        );
+    }
+}
+
+#[test]
+fn is_test_package_rejects_non_test_names() {
+    assert!(!is_test_package(&PyPIPackageName::from("requests")));
+    assert!(!is_test_package(&PyPIPackageName::from("safe-chain")));
+    assert!(!is_test_package(&PyPIPackageName::from(
+        "safe-chain-pi-tester"
+    )));
+}
+
+fn uri(path: &str) -> Uri {
+    path.parse().expect("test paths must parse")
+}
+
+#[test]
+fn synthesize_returns_none_for_non_test_package() {
+    assert!(synthesize_metadata_response(&uri("/simple/requests/")).is_none());
+    assert!(synthesize_metadata_response(&uri("/pypi/requests/json")).is_none());
+}
+
+#[test]
+fn synthesize_returns_none_for_artifact_path() {
+    assert!(
+        synthesize_metadata_response(&uri(
+            "/packages/00/00/safe_chain_pi_test-0.1.0-py3-none-any.whl"
+        ))
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn synthesize_simple_advertises_wheel_url_for_each_test_package() {
+    for &name in TEST_PACKAGES {
+        let req_uri = uri(&format!("/simple/{name}/"));
+        let resp = synthesize_metadata_response(&req_uri).expect("must synthesize");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_to_string(resp).await;
+        let expected_url = wheel_url(name);
+        assert!(
+            body.contains(&expected_url),
+            "expected synthesized HTML to advertise {expected_url}, got body: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn synthesize_json_for_pypi_json_path() {
+    let req_uri = uri("/pypi/safe-chain-pi-test/json");
+    let resp = synthesize_metadata_response(&req_uri).expect("must synthesize");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_to_string(resp).await;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&body).expect("synthesized body must be valid JSON");
+    assert_eq!(parsed["info"]["name"], "safe-chain-pi-test");
+    assert_eq!(parsed["info"]["version"], "0.1.0");
+    assert_eq!(parsed["urls"][0]["url"], wheel_url("safe-chain-pi-test"));
+}
+
+async fn body_to_string(resp: Response) -> String {
+    use rama::http::body::util::BodyExt as _;
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect synthetic body")
+        .to_bytes();
+    String::from_utf8(bytes.to_vec()).expect("synthetic body is utf-8")
+}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added synthetic PyPI test-package metadata and blocked test downloads

**⚡ Enhancements**
* Mock PyPI registry served PEP 503 simple HTML and JSON


<sup>[More info](https://app.aikido.dev/featurebranch/scan/113327425?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->